### PR TITLE
attempt to open _blank link targets in OS's default browser, not electron

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,4 +1,4 @@
-import {ipcRenderer} from 'electron';
+import {ipcRenderer, shell} from 'electron';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GUI, {AppStateHOC} from 'scratch-gui';
@@ -9,6 +9,12 @@ import styles from './app.css';
 
 const defaultProjectId = 0;
 
+// override window.open so that it uses the OS's default browser, not an electron browser
+window.open = function (url, target) {
+    if (target === '_blank') {
+        shell.openExternal(url);
+    }
+};
 // Register "base" page view
 // analytics.pageview('/');
 


### PR DESCRIPTION
Use the `electron.shell.openExternal` function to open all links that call `window.open` with a `_blank` target.

Resolves https://github.com/LLK/scratch-desktop/issues/9

**NOTE**: temporarily, commented out code is included, for discussion.

Example:

![dec-21-2018 15-15-52](https://user-images.githubusercontent.com/3431616/50367293-fd245b00-0533-11e9-9d04-2dbe0b47a483.gif)
