### PR TITLE
Include menu with default keyboard shortcuts to allow mac to work

### DIFF
--- a/src/main/MacOSMenu.js
+++ b/src/main/MacOSMenu.js
@@ -1,0 +1,50 @@
+// Include the standard keyboard shortcuts in the edit menu
+// so they can be used within the app. Only needed on Mac.
+export default app => ([
+    {
+        label: 'App', // Always overridden by app name
+        submenu: [{
+            label: 'Quit',
+            accelerator: 'CmdOrCtrl+Q',
+            click: () => app.quit()
+        }]
+    },
+    {
+        label: 'Edit',
+        submenu: [
+            {
+                label: 'Undo',
+                accelerator: 'CmdOrCtrl+Z',
+                role: 'undo'
+            },
+            {
+                label: 'Redo',
+                accelerator: 'Shift+CmdOrCtrl+Z',
+                role: 'redo'
+            },
+            {
+                type: 'separator'
+            },
+            {
+                label: 'Cut',
+                accelerator: 'CmdOrCtrl+X',
+                role: 'cut'
+            },
+            {
+                label: 'Copy',
+                accelerator: 'CmdOrCtrl+C',
+                role: 'copy'
+            },
+            {
+                label: 'Paste',
+                accelerator: 'CmdOrCtrl+V',
+                role: 'paste'
+            },
+            {
+                label: 'Select All',
+                accelerator: 'CmdOrCtrl+A',
+                role: 'selectall'
+            }
+        ]
+    }
+]);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,7 +1,8 @@
-import {BrowserWindow, app, dialog} from 'electron';
+import {BrowserWindow, Menu, app, dialog} from 'electron';
 import * as path from 'path';
 import {format as formatUrl} from 'url';
 import telemetry from './ScratchDesktopTelemetry';
+import MacOSMenu from './MacOSMenu';
 
 telemetry.appWasOpened();
 
@@ -19,6 +20,11 @@ const createMainWindow = () => {
         show: false
     });
     const webContents = window.webContents;
+
+    if (process.platform === 'darwin') {
+        const osxMenu = Menu.buildFromTemplate(MacOSMenu(app));
+        Menu.setApplicationMenu(osxMenu);
+    }
 
     if (isDevelopment) {
         webContents.openDevTools();


### PR DESCRIPTION
Folllowed https://blog.avocode.com/4-must-know-tips-for-building-cross-platform-electron-apps-f3ae9c2bffff to include the menu items for the shortcuts we use within the app, which seems to fix the issues with using them on Mac. @cwillisf I think you'd have to confirm this doesn't change anything in Windows, although since it is under the `if platform darwin` switch I doubt it would. Does this seem like a good solution?

Fixes https://github.com/LLK/scratch-desktop/issues/1