### PR TITLE
Show main window ASAP, even if it's just a loading screen

### DIFF
--- a/electron-webpack.json5
+++ b/electron-webpack.json5
@@ -3,6 +3,7 @@
         "webpackConfig": "webpack.main.additions.js"
     },
     "renderer": {
+        "template": "src/renderer/index.html",
         "webpackConfig": "webpack.renderer.additions.js"
     }
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,8 +3,14 @@
 <head>
     <meta charset="utf-8">
     <style>
+        body {
+           background-color: #4D97FF;
+        }
         .splash {
+            color: white;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             font-size: xx-large;
+            font-weight: bolder;
             margin: 0;
             position: absolute;
             top: 50%;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        .splash {
+            font-size: xx-large;
+            margin: 0;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+    </style>
+</head>
+<body>
+    <div id="app"><p class="splash">Scratch Desktop is loading...</p></div>
+</body>
+</html>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,1 +1,3 @@
-import './app.jsx';
+// this is an async import so that it doesn't block the first render
+// index.html contains a loading/splash screen which will display while this import loads
+import('./app.jsx');


### PR DESCRIPTION
Resolves #59 

There are two parts to this change:
- Make a new, tiny stub JS file which does nothing but load the "real" JS asynchronously. This by itself allows the main window to appear quickly, though it's just an empty white window.
- Override the render process `index.html` with one which contains a loading message. This causes the empty to instead display that loading message until the GUI's loading screen takes over.

The `app.js` here is `index.js` renamed with no changes.

Marking this as a draft PR since the current loading screen is a temporary placeholder ;)

CC @paulkaplan - this kind of approach may also be interesting for other platforms...

CC @carljbowman - we should talk about what the loading screen should look like