### PR TITLE
telemetry: add 'platform' and improve 'version'

### DIFF
--- a/src/main/ScratchDesktopTelemetry.js
+++ b/src/main/ScratchDesktopTelemetry.js
@@ -1,10 +1,11 @@
 import {app, ipcMain} from 'electron';
 import defaultsDeep from 'lodash.defaultsdeep';
+import {version} from '../../package.json';
 
 import TelemetryClient from './telemetry/TelemetryClient';
 
 const EVENT_TEMPLATE = {
-    version: '3.0.0',
+    version,
     projectName: '',
     language: '',
     metadata: {

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -1,5 +1,6 @@
 import ElectronStore from 'electron-store';
 import nets from 'nets';
+import * as os from 'os';
 import uuidv1 from 'uuid/v1'; // semi-persistent client ID
 import uuidv4 from 'uuid/v4'; // random ID
 
@@ -17,7 +18,7 @@ import uuidv4 from 'uuid/v4'; // random ID
   * Default telemetry service URLs
   */
 const TelemetryServerURL = Object.freeze({
-    staging: 'http://scratch-telemetry-s.us-east-1.elasticbeanstalk.com/',
+    staging: 'http://scratch-telemetry-staging.us-east-1.elasticbeanstalk.com/',
     production: 'https://telemetry.scratch.mit.edu/'
 });
 const DefaultServerURL = (
@@ -48,6 +49,12 @@ const DefaultQueueLimit = 100;
  * Default limit on the number of delivery attempts for each event
  */
 const DeliveryAttemptLimit = 3;
+
+const platform = [
+    `${os.platform()} ${os.release()}`, // "win32 10.0.18362", "darwin 18.7.0", etc.
+    `Electron ${process.versions.electron}`, // "Electron 4.2.6"
+    `Store=${process.mas || process.windowsStore || false}` // "Store=true" or "Store=false"
+].join(', ');
 
 
 /**
@@ -213,6 +220,7 @@ class TelemetryClient {
             clientID: this.clientID,
             id: packetId,
             name: eventName,
+            platform,
             timestamp: now.getTime(),
             userTimezone: now.getTimezoneOffset()
         }, additionalFields);


### PR DESCRIPTION
The `version` field is now reported directly from `package.json`. There is a version field in `process` as well, but in development builds that can report the version of Node or Electron instead of the application's version. Reading straight from `package.json` means you need to get the path right, which looks kludgy, but at least you always get the right version number.

Version numbers will look like `3.5.1` with no `v` at the beginning.

The `platform` string is built from pieces read out of the Node/Electron global `process` and the standard Node/Electron `os` module. One downside of this is that macOS is reported using the internal version numbers rather than the consumer-facing numbers. The mapping is documented here: https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history

Example platform strings from this code:

> win32 10.0.18362, Electron 4.2.8, Store=false

> darwin 18.7.0, Electron 4.2.8, Store=false

It's easy to change the formatting so please let me know if something else would be easier to parse on the back end.

CC @paulkaplan 