### PR TITLE
DesktopHOC manages project title, rather than wrapping with TitledHOC

### DIFF
--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -73,8 +73,10 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         render () {
             const shouldShowTelemetryModal = (typeof ipcRenderer.sendSync('getTelemetryDidOptIn') !== 'boolean');
             return (<WrappedComponent
+                canEditTitle
                 isScratchDesktop
                 projectId={defaultProjectId}
+                projectTitle={this.state.projectTitle}
                 showTelemetryModal={shouldShowTelemetryModal}
                 onClickLogo={this.handleClickLogo}
                 onProjectTelemetryEvent={this.handleProjectTelemetryEvent}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -36,8 +36,12 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 'handleSetTitleFromSave',
                 'handleStorageInit',
                 'handleTelemetryModalOptIn',
-                'handleTelemetryModalOptOut'
+                'handleTelemetryModalOptOut',
+                'handleUpdateProjectTitle'
             ]);
+            this.state = {
+                projectTitle: null
+            };
         }
         componentDidMount () {
             ipcRenderer.on('setTitleFromSave', this.handleSetTitleFromSave);
@@ -52,7 +56,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
             ipcRenderer.send(event, metadata);
         }
         handleSetTitleFromSave (event, args) {
-            this.props.onUpdateProjectTitle(args.title);
+            this.handleUpdateProjectTitle(args.title);
         }
         handleStorageInit (storageInstance) {
             storageInstance.addHelper(new ElectronStorageHelper(storageInstance));
@@ -62,6 +66,9 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         }
         handleTelemetryModalOptOut () {
             ipcRenderer.send('setTelemetryDidOptIn', false);
+        }
+        handleUpdateProjectTitle (newTitle) {
+            this.setState({projectTitle: newTitle});
         }
         render () {
             const shouldShowTelemetryModal = (typeof ipcRenderer.sendSync('getTelemetryDidOptIn') !== 'boolean');
@@ -74,14 +81,11 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 onStorageInit={this.handleStorageInit}
                 onTelemetryModalOptIn={this.handleTelemetryModalOptIn}
                 onTelemetryModalOptOut={this.handleTelemetryModalOptOut}
+                onUpdateProjectTitle={this.handleUpdateProjectTitle}
                 {...this.props}
             />);
         }
     }
-
-    ScratchDesktopComponent.propTypes = {
-        onUpdateProjectTitle: PropTypes.func
-    };
 
     return ScratchDesktopComponent;
 };
@@ -91,8 +95,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
 // ability to compose reducers.
 const WrappedGui = compose(
     AppStateHOC,
-    TitledHOC,
-    ScratchDesktopHOC // must come after `TitledHOC` so it has access to `onUpdateProjectTitle`
+    ScratchDesktopHOC
 )(GUI);
 
 ReactDOM.render(<WrappedGui />, appTarget);


### PR DESCRIPTION
https://github.com/LLK/scratch-gui/pull/5168 proposed a refactor where TitledHOC changed its role from:
Before: "wrap GUI and maintain projectTitle state, if no other external parent is maintaining it"
to
After: "wrap GUI and interface between external parent's projectTitle prop, and GUI's redux projectTitle"

This means that TitledHOC can't be used to wrap ScratchDesktopHOC anymore -- it no longer does the thing we used it for. Instead, ScratchDesktopHOC needs to maintain its own projectTitle state, since the main Electron process may send a projectTitle in on file load.

Important: this should only be merged if https://github.com/LLK/scratch-gui/pull/5168 is also merged. https://github.com/LLK/scratch-gui/pull/5168 should be merged first, so the resulting version of GUI can be used by scratch-desktop.