### PR TITLE
Skip signing appx

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf ./dist/ ./static/assets/",
     "compile": "rimraf ./dist/ && electron-webpack --bail --display-error-details --env.minify=false",
     "fetch": "rimraf ./static/assets/ && mkdirp ./static/assets/ && node ./scripts/fetchMediaLibraryAssets.js",
-    "dist": "npm run build-gui && npm run fetch && npm run compile -p && electron-builder",
+    "dist": "npm run build-gui && npm run fetch && npm run compile -p && node ./scripts/electron-builder-wrapper.js",
     "dist:dir": "npm run dist -- --dir -c.compression=store -c.mac.identity=null",
     "lint": "eslint --cache --color --ext .jsx,.js ."
   },

--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -1,0 +1,56 @@
+const {spawnSync} = require('child_process');
+
+const stripCSC = function (environment) {
+    const {
+        CSC_LINK: _CSC_LINK,
+        CSC_KEY_PASSWORD: _CSC_KEY_PASSWORD,
+        WIN_CSC_LINK: _WIN_CSC_LINK,
+        WIN_CSC_KEY_PASSWORD: _WIN_CSC_KEY_PASSWORD,
+        ...strippedEnvironment
+    } = environment;
+    return strippedEnvironment;
+};
+
+const getPlatformFlag = function () {
+    switch (process.platform) {
+    case 'win32': return '--windows';
+    case 'darwin': return '--macos';
+    case 'linux': return '--linux';
+    }
+    throw new Error(`Could not determine platform flag for platform: ${process.platform}`);
+}
+
+const runBuilder = function (targetGroup) {
+    // the appx build fails if CSC_* or WIN_CSC_* variables are set
+    const shouldStripCSC = (targetGroup === 'appx');
+    const childEnvironment = shouldStripCSC ? stripCSC(process.env) : process.env;
+    if ((targetGroup === 'nsis') && !(childEnvironment.CSC_LINK || childEnvironment.WIN_CSC_LINK)) {
+        throw new Error(`NSIS build requires CSC_LINK or WIN_CSC_LINK`);
+    }
+    const platformFlag = getPlatformFlag();
+    const command = `electron-builder ${platformFlag} ${targetGroup}`;
+    console.log(`running: ${command}`);
+    spawnSync(command, {
+        env: childEnvironment,
+        shell: true,
+        stdio: 'inherit'
+    });
+};
+
+const calculateTargets = function () {
+    switch (process.platform) {
+    case 'win32':
+        // run in two passes so we can skip signing the appx
+        return ['nsis', 'appx'];
+    case 'darwin':
+        // run in one pass for slightly better speed
+        return ['dmg mas'];
+    }
+    throw new Error(`Could not determine targets for platform: ${process.platform}`);
+};
+
+// TODO: allow user to specify targets? We could theoretically build NSIS on Mac, for example.
+const targets = calculateTargets();
+for (const targetGroup of targets) {
+    runBuilder(targetGroup);
+}


### PR DESCRIPTION
(I wasn't sure who would want to review this... feel free to reassign!)

This change brings us one step closer to automated builds of Scratch Desktop. Running `npm run dist` will now build the DMG and MAS targets on Mac or the NSIS and AppX targets on Windows -- together, those are the four targets we release.

Running `electron-builder` with no arguments seems like it should already do that on paper, but unfortunately there's a conflict between code-signing settings for NSIS and AppX. Specifically, the NSIS build needs `CSC_*` or `WIN_CSC_*` variables set in order to make a signed build, and if those variables are set when doing the AppX build then `electron-builder` tries to sign the AppX build with the same settings. Unfortunately AppX code signing requires different settings, and trying to sign the AppX with the NSIS-compatible settings causes the AppX build to fail.

In our case (distributing through the Microsoft Store) the AppX should actually not be signed before uploading to the store, which corresponds to omitting the `CSC_*` and `WIN_CSC_*` environment variables. This script does just that.

The behavior of the script on each platform is:
- Mac: build the Mac App Store (`mas`) and direct-download (`dmg`) targets in one pass without doing anything to the environment variables.
- Windows: run `electron-builder` twice:
   - Build the direct-download (`nsis`) target without changing any environment variables. (Actually, first check that `CSC_LINK` or `WIN_CSC_LINK` is set since it's easy to forget...)
   - Build the Microsoft Store (`appx`) target with a filtered copy of the environment variables, omitting the relevant `CSC_*` and `WIN_CSC_*` values.
