### PR TITLE
Better project save detection

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -94,13 +94,15 @@ const createMainWindow = () => {
             const userChosenPath = dialog.showSaveDialog(window, options);
             if (userChosenPath) {
                 item.setSavePath(userChosenPath);
-                const newProjectTitle = path.basename(userChosenPath, extName);
-                webContents.send('setTitleFromSave', {title: newProjectTitle});
+                if (extNameNoDot.toUpperCase() == "SB3") { // when a project is downloaded, not an asset
+                    const newProjectTitle = path.basename(userChosenPath, extName);
+                    webContents.send('setTitleFromSave', {title: newProjectTitle});
 
-                // "setTitleFromSave" will set the project title but GUI has already reported the telemetry event
-                // using the old title. This call lets the telemetry client know that the save was actually completed
-                // and the event should be committed to the event queue with this new title.
-                telemetry.projectSaveCompleted(newProjectTitle);
+                    // "setTitleFromSave" will set the project title but GUI has already reported the telemetry event
+                    // using the old title. This call lets the telemetry client know that the save was actually completed
+                    // and the event should be committed to the event queue with this new title.
+                    telemetry.projectSaveCompleted(newProjectTitle);
+                }
             } else {
                 item.cancel();
                 telemetry.projectSaveCanceled();

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -73,6 +73,14 @@ const createAboutWindow = () => {
     return window;
 };
 
+const getIsProjectSave = downloadItem => {
+    switch (downloadItem.getMimeType()) {
+    case 'application/x.scratch.sb3':
+        return true;
+    }
+    return false;
+};
+
 const createMainWindow = () => {
     const window = createWindow({
         width: defaultSize.width,
@@ -82,29 +90,32 @@ const createMainWindow = () => {
     const webContents = window.webContents;
 
     webContents.session.on('will-download', (ev, item) => {
+        const isProjectSave = getIsProjectSave(item);
         const itemPath = item.getFilename();
         const baseName = path.basename(itemPath);
         const extName = path.extname(baseName);
+        const options = {
+            defaultPath: baseName
+        };
         if (extName) {
             const extNameNoDot = extName.replace(/^\./, '');
-            const options = {
-                defaultPath: baseName,
-                filters: [getFilterForExtension(extNameNoDot)]
-            };
-            const userChosenPath = dialog.showSaveDialog(window, options);
-            if (userChosenPath) {
-                item.setSavePath(userChosenPath);
-                if (extNameNoDot.toUpperCase() == "SB3") { // when a project is downloaded, not an asset
-                    const newProjectTitle = path.basename(userChosenPath, extName);
-                    webContents.send('setTitleFromSave', {title: newProjectTitle});
+            options.filters = [getFilterForExtension(extNameNoDot)];
+        }
+        const userChosenPath = dialog.showSaveDialog(window, options);
+        if (userChosenPath) {
+            item.setSavePath(userChosenPath);
+            if (isProjectSave) {
+                const newProjectTitle = path.basename(userChosenPath, extName);
+                webContents.send('setTitleFromSave', {title: newProjectTitle});
 
-                    // "setTitleFromSave" will set the project title but GUI has already reported the telemetry event
-                    // using the old title. This call lets the telemetry client know that the save was actually completed
-                    // and the event should be committed to the event queue with this new title.
-                    telemetry.projectSaveCompleted(newProjectTitle);
-                }
-            } else {
-                item.cancel();
+                // "setTitleFromSave" will set the project title but GUI has already reported the telemetry event
+                // using the old title. This call lets the telemetry client know that the save was actually completed
+                // and the event should be committed to the event queue with this new title.
+                telemetry.projectSaveCompleted(newProjectTitle);
+            }
+        } else {
+            item.cancel();
+            if (isProjectSave) {
                 telemetry.projectSaveCanceled();
             }
         }


### PR DESCRIPTION
### Resolves

Resolves #72 
Closes #73 

### Proposed Changes

This change is based on #73 but is implemented in terms of the `DownloadItem`'s content type instead of its file extension. I believe this sets us more for better reliability & future-proofing, though right now the difference is pretty theoretical.

Bonus fixes for this version of the change include trying to cancel the current project save telemetry event only if the item is actually a project save, and fixing a theoretical case where saving a file without an extension could cause the save dialog to not appear.

### Reason for Changes

The change from @apple502j was great and only needed one or two tweaks, but since #72 has been marked "critical" I decided to go ahead and make these changes instead of just suggesting changes on #73. I really appreciate the work that @apple502j put into #73 and the inspiration that PR provided for this one!
