### PR TITLE
Use dist path for library JSON files of GUI

### DIFF
--- a/scripts/lib/libraries.js
+++ b/scripts/lib/libraries.js
@@ -1,7 +1,7 @@
-const backdrops = require('scratch-gui/src/lib/libraries/backdrops.json');
-const costumes = require('scratch-gui/src/lib/libraries/costumes.json');
-const sounds = require('scratch-gui/src/lib/libraries/sounds.json');
-const sprites = require('scratch-gui/src/lib/libraries/sprites.json');
+const backdrops = require('scratch-gui/dist/libraries/backdrops.json');
+const costumes = require('scratch-gui/dist/libraries/costumes.json');
+const sounds = require('scratch-gui/dist/libraries/sounds.json');
+const sprites = require('scratch-gui/dist/libraries/sprites.json');
 
 const libraries = {
     backdrops,


### PR DESCRIPTION
In conjunction with https://github.com/LLK/scratch-gui/pull/5277, since we removed /src from the published gui files. See that PR for more details

