### PR TITLE
Support loading a project from the command line

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+// suppress "--inspect=" parameter applied automatically by "electron-webpack dev"
+ELECTRON_ARGS=[]

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "source-map-loader": "^0.2.4",
     "uglifyjs-webpack-plugin": "^2.1.3",
     "uuid": "^3.3.3",
-    "webpack": "^4.39.3"
+    "webpack": "^4.39.3",
+    "yargs": "^13.3.0"
   },
   "resolutions": {
     "upath": "^1.0.5"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,8 @@
 import {BrowserWindow, Menu, app, dialog, ipcMain} from 'electron';
-import * as path from 'path';
+import path from 'path';
 import {format as formatUrl} from 'url';
+import yargs from 'yargs';
+
 import {getFilterForExtension} from './FileFilters';
 import telemetry from './ScratchDesktopTelemetry';
 import MacOSMenu from './MacOSMenu';
@@ -12,6 +14,16 @@ telemetry.appWasOpened();
 const defaultSize = {width: 1280, height: 800}; // good for MAS screenshots
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const args = yargs
+    .command({
+        command: '$0 [project-file]', // "app.exe file.sb3"
+        aliases: ['dev'], // for compatibility with "electron-webpack dev"
+        desc: 'Start Scratch 3.0 standalone application. Optionally, load a project file.'
+    })
+    .strict(false) // ignore args meant for Electron
+    .help()
+    .argv;
 
 // global window references prevent them from being garbage-collected
 const _windows = {};
@@ -170,6 +182,12 @@ app.on('ready', () => {
     });
 });
 
+// let the render process open the "about" window
 ipcMain.on('open-about-window', () => {
     _windows.about.show();
+});
+
+// let the render process retrieve parsed args
+ipcMain.on('get-args', event => {
+    event.returnValue = args;
 });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -16,12 +16,13 @@ const defaultSize = {width: 1280, height: 800}; // good for MAS screenshots
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
 const args = yargs
-    .command({
-        command: '$0 [project-file]', // "app.exe file.sb3"
-        aliases: ['dev'], // for compatibility with "electron-webpack dev"
-        desc: 'Start Scratch 3.0 standalone application. Optionally, load a project file.'
+    .command('$0 [projectPath]', 'Start Scratch 3.0 standalone application', innerYargs => {
+        innerYargs
+            .positional('[projectPath]', {
+                describe: 'Path to a project file to open'
+            })
+            .demand(0, 1);
     })
-    .strict(false) // ignore args meant for Electron
     .help()
     .argv;
 

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -12,6 +12,9 @@ import styles from './app.css';
 
 const defaultProjectId = 0;
 
+// TODO: switch from "sendSync" to "invoke" once we're using Electron 7+
+let oneTimeArgs = ipcRenderer.sendSync('get-args');
+
 // override window.open so that it uses the OS's default browser, not an electron browser
 window.open = function (url, target) {
     if (target === '_blank') {
@@ -65,7 +68,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         }
         render () {
             const shouldShowTelemetryModal = (typeof ipcRenderer.sendSync('getTelemetryDidOptIn') !== 'boolean');
-            return (<WrappedComponent
+            const wrappedComponent = (<WrappedComponent
                 isScratchDesktop
                 projectId={defaultProjectId}
                 showTelemetryModal={shouldShowTelemetryModal}
@@ -76,6 +79,15 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 onTelemetryModalOptOut={this.handleTelemetryModalOptOut}
                 {...this.props}
             />);
+            if (oneTimeArgs) {
+                const projectFileName = oneTimeArgs.projectFile;
+                oneTimeArgs = null;
+
+                process.nextTick(() => {
+                    console.log('I should load:', projectFileName);
+                });
+            }
+            return wrappedComponent;
         }
     }
 

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -44,25 +44,25 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 'handleTelemetryModalOptOut'
             ]);
             this.state = {
-                // projectFileName is used as "do we want to wait for a project file to load?"
-                projectFileName: mainProcessArgs.projectFile,
+                // projectPath is used as "do we want to wait for a project file to load?"
+                projectPath: mainProcessArgs.projectPath,
                 projectData: null
             };
         }
         componentDidMount () {
             ipcRenderer.on('setTitleFromSave', this.handleSetTitleFromSave);
-            if (this.state.projectFileName) {
-                fs.readFile(this.state.projectFileName, null, (err, data) => {
+            if (this.state.projectPath) {
+                fs.readFile(this.state.projectPath, null, (err, data) => {
                     if (err) {
                         remote.dialog.showMessageBox({
                             type: 'error',
                             title: 'Failed to load project',
-                            message: `Could not load project from file:\n${this.state.projectFileName}`,
+                            message: `Could not load project from file:\n${this.state.projectPath}`,
                             detail: err.message,
                             buttons: ['OK']
                         });
                         // just open a blank editor
-                        this.setState({projectFileName: null});
+                        this.setState({projectPath: null});
                     } else {
                         // render the GUI with the now-loaded project data
                         this.setState({projectData: data});
@@ -92,7 +92,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
             ipcRenderer.send('setTelemetryDidOptIn', false);
         }
         render () {
-            if (this.state.projectFileName && !this.state.projectData) {
+            if (this.state.projectPath && !this.state.projectData) {
                 return <p className="splash">Loading File...</p>;
             }
             const shouldShowTelemetryModal = (typeof ipcRenderer.sendSync('getTelemetryDidOptIn') !== 'boolean');


### PR DESCRIPTION
## DRAFT

This PR is a draft; I plan to improve the error messages and possibly set them up for localization, depending on the results of a few upcoming conversations.

### Resolves

This is a major step toward resolving #32

### Proposed Changes

If the application is launched with a project file name on the command line, we now attempt to load that project file as the initial project in the GUI. If loading fails we display the error message and load the GUI with the default project. If no project file name is specified on the command line we load the GUI with the default project, as before.

### Reason for Changes

The easiest way to resolve #32 is to set up loading a file from the command line (this change) then setting the installer to register the appropriate file associations with the OS. This change implements the first half of that approach.

This feature has also been requested independently of #32.

CC @BryceLTaylor 
