### PR TITLE
Added linux tar as a target

### DIFF
--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -71,6 +71,8 @@ const calculateTargets = function () {
     case 'darwin':
         // run in one pass for slightly better speed
         return ['dmg mas'];
+    case 'linux':
+        return ['tar.xz'];            
     }
     throw new Error(`Could not determine targets for platform: ${process.platform}`);
 };


### PR DESCRIPTION
Is there a reason why linux is not targetted?

Please feel free to update to support other linux distributions.