### PR TITLE
Support 3.0 library syntax when fetching assets

### DIFF
--- a/scripts/fetchMediaLibraryAssets.js
+++ b/scripts/fetchMediaLibraryAssets.js
@@ -23,9 +23,13 @@ const collectSimple = function (library, dest, debugLabel = 'Item') {
             ++md5Count;
             dest.add(item.md5);
         }
-        if (item.baseLayerMD5) {
+        if (item.baseLayerMD5) { // 2.0 library syntax for costumes
             ++md5Count;
             dest.add(item.baseLayerMD5);
+        }
+        if (item.md5ext) { // 3.0 library syntax for costumes
+            ++md5Count;
+            dest.add(item.md5ext);
         }
         if (md5Count < 1) {
             console.warn(`${debugLabel} has no MD5 property:\n${describe(item)}`);


### PR DESCRIPTION
### Resolves 

_What Github issue does this resolve (please include link)?_

- Resolves https://github.com/LLK/scratch-desktop/issues/92

### Proposed Changes

_Describe what this Pull Request does_

Support `.md5ext` property if it exists in the library items. This is a change that will be made when the library JSON format is changed to match the 3.0 sprite syntax