### PR TITLE
upgrade to electron@^6.1.7 with MAS patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3827,9 +3827,9 @@
       "dev": true
     },
     "electron": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.9.tgz",
-      "integrity": "sha512-zC7K3GOiZKmxqllVG/qq/Gx+qQvyolKj5xKKwXMqIGekfokEW2hvoIO5Yh7KCoAh5dqBtpzOJjS4fj1se+YBcg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.1.7.tgz",
+      "integrity": "sha512-QhBA/fcYJit2XJGkD2xEfxlWTtTaWYu7qkKVohtVWXpELFqkpel2DCDxet5BTo0qs8ukuZHxlQPnIonODnl2bw==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-react-intl": "^2.3.1",
     "copy-webpack-plugin": "^4.6.0",
-    "electron": "^4.2.9",
+    "electron": "^6.1.7",
     "electron-builder": "^20.44.4",
     "electron-devtools-installer": "^2.2.4",
     "electron-store": "^3.3.0",


### PR DESCRIPTION
This version of Electron includes a patch which:
- removes the use of some private APIs which were causing Electron apps to be rejected by the Mac App Store, but
- might cause degraded performance on Mac.