### PR TITLE
work around startup hang in dev on Win10 dark mode

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,8 @@
 import {BrowserWindow, Menu, app, dialog, ipcMain} from 'electron';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import {format as formatUrl} from 'url';
+
 import {getFilterForExtension} from './FileFilters';
 import telemetry from './ScratchDesktopTelemetry';
 import MacOSMenu from './MacOSMenu';
@@ -28,22 +30,8 @@ const createWindow = ({search = null, url = 'index.html', ...browserWindowOption
     const webContents = window.webContents;
 
     if (isDevelopment) {
-        webContents.openDevTools();
-        import('electron-devtools-installer').then(importedModule => {
-            const {default: installExtension, REACT_DEVELOPER_TOOLS} = importedModule;
-            installExtension(REACT_DEVELOPER_TOOLS);
-            // TODO: add logging package and bring back the lines below
-            // .then(name => console.log(`Added browser extension:  ${name}`))
-            // .catch(err => console.log('An error occurred: ', err));
-        });
+        webContents.openDevTools({mode: 'detach', activate: true});
     }
-
-    webContents.on('devtools-opened', () => {
-        window.focus();
-        setImmediate(() => {
-            window.focus();
-        });
-    });
 
     const fullUrl = formatUrl(isDevelopment ?
         { // Webpack Dev Server
@@ -166,8 +154,41 @@ app.on('will-quit', () => {
     telemetry.appWillClose();
 });
 
+// work around https://github.com/MarshallOfSound/electron-devtools-installer/issues/122
+// which seems to be a result of https://github.com/electron/electron/issues/19468
+if (process.platform === 'win32') {
+    const appUserDataPath = app.getPath('userData');
+    const devToolsExtensionsPath = path.join(appUserDataPath, 'DevTools Extensions');
+    try {
+        fs.unlinkSync(devToolsExtensionsPath);
+    } catch (_) {
+        // don't complain if the file doesn't exist
+    }
+}
+
 // create main BrowserWindow when electron is ready
 app.on('ready', () => {
+    if (isDevelopment) {
+        import('electron-devtools-installer').then(importedModule => {
+            const {default: installExtension, ...devToolsExtensions} = importedModule;
+            const extensionsToInstall = [
+                devToolsExtensions.REACT_DEVELOPER_TOOLS,
+                devToolsExtensions.REACT_PERF,
+                devToolsExtensions.REDUX_DEVTOOLS
+            ];
+            for (const extension of extensionsToInstall) {
+                // WARNING: depending on a lot of things including the version of Electron `installExtension` might
+                // return a promise that never resolves, especially if the extension is already installed.
+                installExtension(extension).then(
+                    // eslint-disable-next-line no-console
+                    extensionName => console.log(`Installed dev extension: ${extensionName}`),
+                    // eslint-disable-next-line no-console
+                    errorMessage => console.error(`Error installing dev extension: ${errorMessage}`)
+                );
+            }
+        });
+    }
+
     _windows.main = createMainWindow();
     _windows.main.on('closed', () => {
         delete _windows.main;


### PR DESCRIPTION
### Resolves

This is a workaround for MarshallOfSound/electron-devtools-installer#122 which seems to be a result of electron/electron#19468.

### Proposed Changes

The main change is to introduce a bit of code which, on Windows only, deletes the file `DevTools Extensions` from Electron's internal storage directory. That's pretty hacky, but short of asking the user to change their system settings this seems to be the only reliable workaround for the issues.

While trying to track down the cause of the problem, I ended up making minor improvements to the way we install DevTools extensions. Those changes are in this PR as well, and include:

- Only install the extensions once instead of once per window.
- Try to report when extension installation succeeds or fails.
- Add extensions to help with React performance inspection and Redux debugging.

### Reason for Changes

There seem to be two workarounds for the DevTools startup hang:

- Don't use the "dark mode" app style in Windows 10 settings, or
- Delete Electron's `DevTools Extensions` file and/or `extensions` directory.

Since I don't want to force a user or developer to change their system settings, I opted for the latter option. Also, deleting the `DevTools Extensions` file should be quicker and possibly more reliable than deleting the directory.

Note that if a user opens the developer panel in a released build, which isn't easy but isn't impossible, they might cause the `DevTools Extensions` file to be created. If they're using Windows 10 dark mode, the app would then hang on next launch despite not being "officially" in development mode. For that reason, the code to delete the `DevTools Extensions` file is not inside a check for development mode.
