### PR TITLE
Fix telemetry modal

### DIFF
--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -96,8 +96,8 @@ const ScratchDesktopHOC = function (WrappedComponent) {
 // the hierarchy of HOC constructor calls clearer here; it has nothing to do with redux's
 // ability to compose reducers.
 const WrappedGui = compose(
-    AppStateHOC,
-    ScratchDesktopHOC
+    ScratchDesktopHOC,
+    AppStateHOC
 )(GUI);
 
 ReactDOM.render(<WrappedGui />, appTarget);


### PR DESCRIPTION
### Resolves

Resolves #99

### Proposed Changes

This change corrects the composition order of the `ScratchDesktopHOC` and the `AppStateHOC` such that the `showTelemetryModal` property gets handled correctly.

### Reason for Changes

Prior to this change, the `showTelemetryModal` was effectively being ignored:

> Warning: React does not recognize the `showTelemetryModal` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `showtelemetrymodal` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Another way to solve this would be to pass the `showTelemetryModal` prop through the chain, but this order of composition fixes the problem without spreading "knowledge" of the telemetry modal any further.
