### PR TITLE
Rename to "Scratch" / "the Scratch app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Scratch 3.0 as a standalone desktop application
 
 This step is temporary: eventually, the `scratch-desktop` branch of the Scratch GUI repository will be merged with
 that repository's main development line. For now, though, the `scratch-desktop` branch holds a few changes that are
-necessary for Scratch Desktop to function correctly but are not yet merged into the main development branch.
+necessary for the Scratch app to function correctly but are not yet merged into the main development branch.
 
 #### Prepare `scratch-gui`: Quick Start
 
@@ -23,7 +23,7 @@ necessary for Scratch Desktop to function correctly but are not yet merged into 
    2. `npm link scratch-gui`
    3. `npm run build-gui` or `npm run watch-gui`
 
-Your copy of `scratch-gui` should now be ready for use with Scratch Desktop.
+Your copy of `scratch-gui` should now be ready for use with the `scratch-desktop` build process.
 
 #### Prepare `scratch-gui`: Detailed Version
 
@@ -85,7 +85,7 @@ Sometimes the macOS build process will result in a build which crashes on startu
 for an entry similar to this:
 
 ```text
-failed to parse entitlements for Scratch Desktop[12345]: OSUnserializeXML: syntax error near line 1
+failed to parse entitlements for Scratch[12345]: OSUnserializeXML: syntax error near line 1
 ```
 
 This appears to be an issue with `codesign` itself. Rebooting your computer and trying to build again might help. Yes,

--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -2,7 +2,7 @@ directories:
   buildResources: buildResources
   output: dist
 appId: edu.mit.scratch.scratch-desktop
-productName: "Scratch Desktop"
+productName: "Scratch"
 afterSign: "scripts/afterSign.js"
 mac:
   category: public.app-category.education

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-desktop",
-  "productName": "Scratch Desktop",
+  "productName": "Scratch",
   "description": "Scratch 3.0 as a self-contained desktop application",
   "author": "Scratch Foundation",
   "version": "3.12.0",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -7,6 +7,7 @@ import {getFilterForExtension} from './FileFilters';
 import telemetry from './ScratchDesktopTelemetry';
 import MacOSMenu from './MacOSMenu';
 import log from '../common/log.js';
+import {productName, version} from '../../package.json';
 
 // suppress deprecation warning; this will be the default in Electron 9
 app.allowRendererProcessReuse = true;
@@ -172,7 +173,7 @@ const createAboutWindow = () => {
         height: 400,
         parent: _windows.main,
         search: 'route=about',
-        title: 'About Scratch Desktop'
+        title: `About ${productName}`
     });
     return window;
 };
@@ -189,7 +190,7 @@ const createMainWindow = () => {
     const window = createWindow({
         width: defaultSize.width,
         height: defaultSize.height,
-        title: 'Scratch Desktop'
+        title: `${productName} ${version}` // something like "Scratch 3.14"
     });
     const webContents = window.webContents;
 

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -26,16 +26,18 @@ const AboutElement = () => (
                 maxHeight: '10rem'
             }}
         /></div>
-        <h2>{productName}</h2>
-        <div>Version {version}</div>
-        <table style={{fontSize: 'x-small'}}>
-            {
-                ['Electron', 'Chrome'].map(component => {
-                    const componentVersion = process.versions[component.toLowerCase()];
-                    return <tr key={component}><td>{component}</td><td>{componentVersion}</td></tr>;
-                })
-            }
-        </table>
+        <div style={{margin: '1.5rem'}}>
+            <h2>{productName}</h2>
+            <div>Version {version}</div>
+            <table style={{fontSize: 'x-small'}}>
+                {
+                    ['Electron', 'Chrome'].map(component => {
+                        const componentVersion = process.versions[component.toLowerCase()];
+                        return <tr key={component}><td>{component}</td><td>{componentVersion}</td></tr>;
+                    })
+                }
+            </table>
+        </div>
     </div>
 );
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -20,6 +20,6 @@
     </style>
 </head>
 <body>
-    <div id="app"><p class="splash">Scratch Desktop is loading...</p></div>
+    <div id="app"><p class="splash">Scratch is loading...</p></div>
 </body>
 </html>


### PR DESCRIPTION
### Resolves

Resolves #126

### Proposed Changes

* Rename the application to "Scratch"
* Update `README.md` to refer to "the Scratch app"
* Change the in-app title bar to "Scratch 3.x" (using the current version number)
* Adjust styling in the "About" window to compensate for the shorter string

### Reason for Changes

To avoid confusion and improve consistency across platforms (web, mobile, etc.) the team has decided to standardize on "Scratch" as the name for the application. The title bar contains the version number to assist in troubleshooting and problem reports.

### Test Coverage

Tested locally by hand.

Note that the apparent CI build failure is due to the fact #130 has not yet been merged and does not indicate a problem with this PR.