### PR TITLE
allow opening dev tools in release builds

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -18,6 +18,22 @@ const defaultSize = {width: 1280, height: 800}; // good for MAS screenshots
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
+const devToolKey = ((process.platform === 'darwin') ?
+    { // macOS: command+option+i
+        alt: true, // option
+        control: false,
+        meta: true, // command
+        shift: false,
+        code: 'KeyI'
+    } : { // Windows: control+shift+i
+        alt: false,
+        control: true,
+        meta: false, // Windows key
+        shift: true,
+        code: 'KeyI'
+    }
+);
+
 // global window references prevent them from being garbage-collected
 const _windows = {};
 
@@ -156,9 +172,19 @@ const createWindow = ({search = null, url = 'index.html', ...browserWindowOption
 
     webContents.session.setPermissionRequestHandler(handlePermissionRequest);
 
-    if (isDevelopment) {
-        webContents.openDevTools({mode: 'detach', activate: true});
-    }
+    webContents.on('before-input-event', (event, input) => {
+        if (input.code === devToolKey.code &&
+            input.alt === devToolKey.alt &&
+            input.control === devToolKey.control &&
+            input.meta === devToolKey.meta &&
+            input.shift === devToolKey.shift &&
+            input.type === 'keyDown' &&
+            !input.isAutoRepeat &&
+            !input.isComposing) {
+            event.preventDefault();
+            webContents.openDevTools({mode: 'detach', activate: true});
+        }
+    });
 
     const fullUrl = makeFullUrl(url, search);
     window.loadURL(fullUrl);


### PR DESCRIPTION
### Proposed Changes

Before: the dev tools window opens automatically in developer builds and is impossible to open in release builds.

After: in all builds, the dev tools window can be opened using the same keyboard shortcut as in Chrome-family browsers (cmd+opt+i on macOS, ctrl+shift+i otherwise). The dev tools no longer open on startup on any build.

### Reason for Changes

This should help debug problems which only occur in release builds, such as #128

Also, we should let advanced users poke at the guts of the app because it's fun and educational :)

### Test Coverage

Tested on macOS 10.14 and Windows 10.