### PR TITLE
make Scratch Link connections work w/o DNS

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -21,6 +21,10 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
 // global window references prevent them from being garbage-collected
 const _windows = {};
 
+// enable connecting to Scratch Link even if we DNS / Internet access is not available
+// this must happen BEFORE the app ready event!
+app.commandLine.appendSwitch('host-resolver-rules', 'MAP device-manager.scratch.mit.edu 127.0.0.1');
+
 const displayPermissionDeniedWarning = (browserWindow, permissionType) => {
     let title;
     let message;


### PR DESCRIPTION
### Resolves

Resolves #31

CC @BryceLTaylor 

### Proposed Changes

Inject `--host-resolver-rules="MAP device-manager.scratch.mit.edu 127.0.0.1"` into the Chromium process's "command line"

### Reason for Changes

This effectively hardcodes `device-manager.scratch.mit.edu` to `127.0.0.1` within Scratch Desktop's "renderer" (browser) process, allowing Scratch Desktop to connect to Scratch Link even if there is no DNS service, or no Internet access at all.

Note that using "host-rules" instead of "host-resolver-rules" doesn't work: it results in `ERR_CERT_COMMON_NAME_INVALID` because the browser expects Scratch Link's certificate to list "127.0.0.1" as its host name. Using "host-resolver-rules" means that the IP is used for the connection only, and not for certificate validation.

See here for more details:
* https://www.electronjs.org/docs/api/command-line-switches#--host-rulesrules
* https://www.electronjs.org/docs/api/command-line-switches#--host-resolver-rulesrules
* https://stackoverflow.com/a/49336439

### Test Coverage

Tested locally with these steps on my Windows 10 dev machine:
1. Turn off WiFi
2. Unplug Ethernet cable
3. Run `ipconfig /flushdns` just to be sure
4. Launch Scratch Link
5. Launch Scratch Desktop built with this change
6. Connect power to a nearby micro:bit
6. Add micro:bit extension in Scratch Desktop
7. See that the nearby micro:bit is listed!

I also verified that several micro:bit blocks worked, but really just seeing it listed -- or even seeing an empty list instead of an error message! -- is a successful test of this change.
