### PR TITLE
fix MAS file overwrite by deleting existing file

### DIFF
--- a/package-deps.json
+++ b/package-deps.json
@@ -14,6 +14,7 @@
     "eslint-config-scratch": "^6.0.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-react": "^7.20.0",
+    "fs-extra": "^9.0.1",
     "mkdirp": "^1.0.4",
     "nets": "^3.2.0",
     "rimraf": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7513,9 +7513,9 @@
       }
     },
     "fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-jest": "^22.14.1",
     "eslint-plugin-react": "^7.20.0",
     "file-loader": "2.0.0",
+    "fs-extra": "^9.0.1",
     "get-float-time-domain-data": "0.1.0",
     "get-user-media-promise": "1.1.4",
     "gh-pages": "github:rschamp/gh-pages#publish-branch-to-subfolder",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -237,6 +237,14 @@ const createMainWindow = () => {
         }
         const userChosenPath = dialog.showSaveDialogSync(window, options);
         if (userChosenPath) {
+            // If the file exists the browser will first download to a temp file then rename to the userChosenPath.
+            // The MAS sandbox allows accessing userChosenPath but not the temp file, so overwriting fails on MAS.
+            // Deleting the file first could be considered risky but works around the sandbox problem.
+            // Security bookmarks might work to fix the problem but they're only supported by async showSaveDialog.
+            // Since we need to use showSaveDialogSync (see WARNING below) this workaround might be the best option.
+            if (fs.existsSync(userChosenPath)) {
+                fs.unlinkSync(userChosenPath);
+            }
             // WARNING: `setSavePath` on this item is only valid during the `will-download` event. Calling the async
             // version of `showSaveDialog` means the event will finish before we get here, so `setSavePath` will be
             // ignored. For that reason we need to call `showSaveDialogSync` above.


### PR DESCRIPTION
### Resolves

Resolves #107

### Proposed Changes

When "downloading" (saving) a file from the Scratch editor, after the user chooses the location and file name using the Save dialog, save the file instead to a temporary location. After the file is saved, move it to the location specified by the user.

The move is done using the `move` function in the `fs-extra` module, which implements the move as a rename if possible (source and destination on the same device, etc.) or a copy+delete otherwise. This module was already a dependency of a dependency, but now is a direct dependency.

The save and move are wrapped in a try/catch which displays any error to the user. In some cases the user may be able to dig into the app's temporary directory to recover from a broken save, so the temporary file is not cleaned up until after the error dialog is dismissed.

### Reason for Changes

The way that Chromium saves files depends in part on whether the destination file already exists. If the file doesn't exist, a new file is created and everything is fine. If the file does exist, Chromium first saves a new file then moves it to overwrite the existing file.

This works great in the direct-download version of Scratch Desktop, but not inside the Mac App Store sandbox.

The Mac App Store (MAS) sandbox allows an app access only to files which the user has explicitly selected. When the user chooses to save over an existing file, Chromium tries to create a file with a similar, but not identical, name. The MAS sandbox denies access to this temporary file, and Chromium reports that the download was "interrupted" (stopped without the ability to resume).

I tried a few other ways to resolve the problem but ran into roadblocks on each path. Here's a short description:
1. Use "app-scoped security bookmarks" as described in electron/electron#11711
   * I'm not actually sure if this would solve the problem, but it was a non-starter because this feature is only present in the asynchronous `showSaveDialog` method. We need to use the synchronous `showSaveDialogSync` method, which doesn't support security bookmarks, because we're overriding the browser's handling of a download item. See the comments on/in 49bb40e for more details.
2. Abandon the browser's handling of the download, and instead download and save the file on the main process ("node") side, as described in the discussion here: electron/electron#2491
   * Unfortunately the URL for the item being downloaded gets to the main process as `blob:...`, which is not a real URL and cannot be accessed from the main process. It might be possible to unpack the blob on in the render (browser) process and send the contents over to the main process, but it's not clear how to connect that with the `will-download` event on the main process. I pursued this for a while but the complexity grew enough that I decided it wasn't worth the maintenance burden.
   * It's possible I've missed an easier way to implement this sort of approach. I might look at this again some time later, but #107 has existed far too long already and I'd like to get a fix out.

Another option would be to request "Full Disk Access" but in my opinion that's a bad idea for at least two reasons. First, I'd rather keep our permissions as restricted as possible. Second, and I admit this is just speculation, doing so might cause problems for users who don't have full administrator access to their computer, including in a school setting.

~This left me with the solution implemented in this PR: once the user chooses the save location, delete any existing file before Chromium checks for it and activates its "replace existing file" code path. The main down-side to this is that if saving the new file somehow goes wrong, it's possible for the old file to be deleted and the new file to be corrupted or not written at all, leading to lost work. That's awful, but it's only possible in the case where you're saving over an existing file, you have permission to delete the old file, but you don't have the ability to write a new file in the same location. In my opinion the chances of this actually happening are slim -- mostly what comes to mind is removing or disconnecting a removable or network drive while the save is in progress, which seems like a recipe for a bad day anyway. It's also important to keep in mind that this is replacing a system which ALWAYS failed to replace an existing file, leading to lost work 100% of the time.~

The second iteration of this PR saves the file to a temporary location, then moves the file to the place the user selected. Since the temporary location is inside the MAS sandbox, the app is free to save files there without user gestures. This effectively makes every save work in a way that is similar to Chromium's behavior in the "replace existing file" case. This approach is safer than the first iteration of this PR, which deleted the file before the save process began, since now we wait until we know that the file has been saved correctly (to the temp location) before replacing the previous version of the file.

### Test Coverage

Tested locally on a `mas-dev` build, a normal `mac` build, and a Windows build. Note that the sandbox problem doesn't show up except in the `mas` and `mas-dev` builds, so it's necessary to test one of those builds explicitly. I also tested normal (non-store) builds on macOS and Windows just to be sure.

The `move` method in `fs-extra` is pretty powerful and can deal with most of the situations that prevent writing files in many other programs. I had to get a little creative when testing error cases.

To generate save errors on macOS:
1. Create a directory for this test, for example: `mkdir ~/test`
2. In Scratch Desktop, save the project to that directory (say, as `~/test/Scratch Project.sb3`)
3. `sudo chown 0:0 ~/test`
4. `sudo chmod -w ~/test`
5. Attempt to save over the existing file. This should fail and display an error message.
6. `sudo rm -r ~/test` to remove the directory after you're done testing, but be careful to type this command correctly!

Generating save errors on Windows is more tricky:
1. In Scratch Desktop, save the project somewhere
2. Find that file and open it in a program which keeps the file handle open. I ran `less "Scratch Desktop.sb3"` but other programs might work.
3. Attempt to save over the existing file. This should fail and display an error message.
4. Once you're done testing, close the program used in step 2 (or close the SB3 file in that program) to release the file handle.
