### PR TITLE
Support loading project file from command line (attempt 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash.bindall": "^4.4.0",
     "lodash.defaultsdeep": "^4.6.1",
     "minilog": "^3.1.0",
+    "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "nets": "^3.2.0",
     "react": "16.2.0",

--- a/src/main/argv.js
+++ b/src/main/argv.js
@@ -1,0 +1,23 @@
+import minimist from 'minimist';
+
+// inspired by yargs' process-argv
+export const isElectronApp = () => !!process.versions.electron;
+export const isElectronBundledApp = () => isElectronApp() && !process.defaultApp;
+
+export const parseAndTrimArgs = argv => {
+    // bundled Electron app: ignore 1 from "my-app arg1 arg2"
+    // unbundled Electron app: ignore 2 from "electron main/index.js arg1 arg2"
+    // node.js app: ignore 2 from "node src/index.js arg1 arg2"
+    const ignoreCount = isElectronBundledApp() ? 1 : 2;
+
+    const parsed = minimist(argv);
+
+    // ignore arguments AFTER parsing to handle cases like "electron --inspect=42 my.js arg1 arg2"
+    parsed._ = parsed._.slice(ignoreCount);
+
+    return parsed;
+};
+
+const argv = parseAndTrimArgs(process.argv);
+
+export default argv;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,6 +2,7 @@ import {BrowserWindow, Menu, app, dialog, ipcMain, systemPreferences} from 'elec
 import fs from 'fs-extra';
 import path from 'path';
 import {URL} from 'url';
+import {promisify} from 'util';
 
 import argv from './argv';
 import {getFilterForExtension} from './FileFilters';
@@ -375,4 +376,28 @@ ipcMain.on('open-about-window', () => {
     _windows.about.show();
 });
 
-ipcMain.handle('get-argv', () => argv);
+// start loading initial project data before the GUI needs it so the load seems faster
+const initialProjectDataPromise = (async () => {
+    if (argv._.length === 0) {
+        // no command line argument means no initial project data
+        return;
+    }
+    if (argv._.length > 1) {
+        log.warn(`Expected 1 command line argument but received ${argv._.length}.`);
+    }
+    const projectPath = argv._[argv._.length - 1];
+    try {
+        const projectData = await promisify(fs.readFile)(projectPath, null);
+        return projectData;
+    } catch (e) {
+        dialog.showMessageBox(_windows.main, {
+            type: 'error',
+            title: 'Failed to load project',
+            message: `Could not load project from file:\n${projectPath}`,
+            detail: e.message
+        });
+    }
+    // load failed: initial project data undefined
+})(); // IIFE
+
+ipcMain.handle('get-initial-project-data', () => initialProjectDataPromise);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import {URL} from 'url';
 
+import argv from './argv';
 import {getFilterForExtension} from './FileFilters';
 import telemetry from './ScratchDesktopTelemetry';
 import MacOSMenu from './MacOSMenu';
@@ -373,3 +374,5 @@ app.on('ready', () => {
 ipcMain.on('open-about-window', () => {
     _windows.about.show();
 });
+
+ipcMain.handle('get-argv', () => argv);

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -6,6 +6,7 @@ import {compose} from 'redux';
 import GUI, {AppStateHOC} from 'scratch-gui';
 
 import ElectronStorageHelper from '../common/ElectronStorageHelper';
+import log from '../common/log';
 
 import styles from './app.css';
 
@@ -98,5 +99,14 @@ const WrappedGui = compose(
     ScratchDesktopHOC,
     AppStateHOC
 )(GUI);
+
+ipcRenderer.invoke('get-argv').then(
+    argv => {
+        log.log(`argv._ = ${argv._}`);
+    },
+    err => {
+        log.warn('Failed to retrieve argv', err);
+    }
+);
 
 ReactDOM.render(<WrappedGui />, appTarget);

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -1,15 +1,32 @@
 import {ipcRenderer, shell} from 'electron';
 import bindAll from 'lodash.bindall';
+import omit from 'lodash.omit';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {connect} from 'react-redux';
 import {compose} from 'redux';
-import GUI, {AppStateHOC} from 'scratch-gui';
+import GUI from 'scratch-gui/src/index';
+import VM from 'scratch-vm';
+
+import AppStateHOC from 'scratch-gui/src/lib/app-state-hoc.jsx';
+import {
+    LoadingStates,
+    onFetchedProjectData,
+    onLoadedProject,
+    defaultProjectId,
+    requestNewProject,
+    requestProjectUpload,
+    setProjectId
+} from 'scratch-gui/src/reducers/project-state';
+import {
+    openLoadingProject,
+    closeLoadingProject
+} from 'scratch-gui/src/reducers/modals';
 
 import ElectronStorageHelper from '../common/ElectronStorageHelper';
 
 import styles from './app.css';
-
-const defaultProjectId = 0;
 
 // override window.open so that it uses the OS's default browser, not an electron browser
 window.open = function (url, target) {
@@ -38,16 +55,29 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 'handleTelemetryModalOptOut',
                 'handleUpdateProjectTitle'
             ]);
-            this.state = {
-                projectTitle: null,
-                projectLoading: true
-            };
+            this.props.onLoadingStarted();
+            ipcRenderer.invoke('get-initial-project-data').then(initialProjectData => {
+                const hasInitialProject = initialProjectData && (initialProjectData.length > 0);
+                this.props.onHasInitialProject(hasInitialProject, this.props.loadingState);
+                if (!hasInitialProject) {
+                    this.props.onLoadingCompleted();
+                    return;
+                }
+                this.props.vm.loadProject(initialProjectData).then(
+                    () => {
+                        this.props.onLoadingCompleted();
+                        this.props.onLoadedProject(this.props.loadingState, true);
+                    },
+                    e => {
+                        this.props.onLoadingCompleted();
+                        console.error(e); // TODO: dialog box reporting the error?
 
-            ipcRenderer.invoke('get-initial-project-data').then(projectData => {
-                this.setState({
-                    projectData,
-                    projectLoading: false
-                });
+                        // abandon this load and instead fetch+load the default project
+                        // WARNING: this stuff doesn't currently work correctly!
+                        this.props.onLoadedProject(this.props.loadingState, false);
+                        this.props.onRequestNewProject();
+                    }
+                );
             });
         }
         componentDidMount () {
@@ -80,15 +110,12 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         render () {
             const shouldShowTelemetryModal = (typeof ipcRenderer.sendSync('getTelemetryDidOptIn') !== 'boolean');
 
-            if (this.state.projectLoading) {
-                return <p className="splash">Loading File...</p>;
-            }
+            const childProps = omit(this.props, Object.keys(ScratchDesktopComponent.propTypes));
 
             return (<WrappedComponent
                 canEditTitle
+                canModifyCloudData={false}
                 isScratchDesktop
-                projectId={defaultProjectId}
-                projectTitle={this.state.projectTitle}
                 showTelemetryModal={shouldShowTelemetryModal}
                 onClickLogo={this.handleClickLogo}
                 onProjectTelemetryEvent={this.handleProjectTelemetryEvent}
@@ -97,25 +124,60 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 onTelemetryModalOptOut={this.handleTelemetryModalOptOut}
                 onUpdateProjectTitle={this.handleUpdateProjectTitle}
 
-                // completely omit the projectData prop if we have no project data
-                // passing an empty projectData causes a GUI error
-                {...(this.state.projectData ? {projectData: this.state.projectData} : {})}
-
                 // allow passed-in props to override any of the above
-                {...this.props}
+                {...childProps}
             />);
         }
     }
 
-    return ScratchDesktopComponent;
+    ScratchDesktopComponent.propTypes = {
+        loadingState: PropTypes.oneOf(LoadingStates),
+        onFetchedInitialProjectData: PropTypes.func,
+        onHasInitialProject: PropTypes.func,
+        onLoadedProject: PropTypes.func,
+        onLoadingCompleted: PropTypes.func,
+        onLoadingStarted: PropTypes.func,
+        onRequestNewProject: PropTypes.func,
+        vm: PropTypes.instanceOf(VM).isRequired
+    };
+    const mapStateToProps = state => {
+        const loadingState = state.scratchGui.projectState.loadingState;
+        return {
+            loadingState: loadingState,
+            vm: state.scratchGui.vm
+        };
+    };
+    const mapDispatchToProps = dispatch => ({
+        onLoadingStarted: () => dispatch(openLoadingProject()),
+        onLoadingCompleted: () => dispatch(closeLoadingProject()),
+        onHasInitialProject: (hasInitialProject, loadingState) => {
+            if (hasInitialProject) {
+                // emulate sb-file-uploader
+                return dispatch(requestProjectUpload(loadingState));
+            }
+
+            // `createProject()` might seem more appropriate but it's not a valid state transition here
+            // setting the default project ID is a valid transition from NOT_LOADED and acts like "create new"
+            return dispatch(setProjectId(defaultProjectId));
+        },
+        onFetchedInitialProjectData: (projectData, loadingState) =>
+            dispatch(onFetchedProjectData(projectData, loadingState)),
+        onLoadedProject: (loadingState, loadSuccess) => {
+            const canSaveToServer = false;
+            return dispatch(onLoadedProject(loadingState, canSaveToServer, loadSuccess));
+        },
+        onRequestNewProject: () => dispatch(requestNewProject(false))
+    });
+
+    return connect(mapStateToProps, mapDispatchToProps)(ScratchDesktopComponent);
 };
 
 // note that redux's 'compose' function is just being used as a general utility to make
 // the hierarchy of HOC constructor calls clearer here; it has nothing to do with redux's
 // ability to compose reducers.
 const WrappedGui = compose(
-    ScratchDesktopHOC,
-    AppStateHOC
+    AppStateHOC,
+    ScratchDesktopHOC
 )(GUI);
 
 ReactDOM.render(<WrappedGui />, appTarget);

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -1,4 +1,4 @@
-import {ipcRenderer, shell} from 'electron';
+import {ipcRenderer, remote, shell} from 'electron';
 import bindAll from 'lodash.bindall';
 import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
@@ -70,11 +70,19 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                     },
                     e => {
                         this.props.onLoadingCompleted();
-                        console.error(e); // TODO: dialog box reporting the error?
-
-                        // abandon this load and instead fetch+load the default project
-                        // WARNING: this stuff doesn't currently work correctly!
                         this.props.onLoadedProject(this.props.loadingState, false);
+                        remote.dialog.showMessageBox(remote.getCurrentWindow(), {
+                            type: 'error',
+                            title: 'Failed to load project',
+                            message: 'Invalid or corrupt project file.',
+                            detail: e.message
+                        });
+
+                        // this effectively sets the default project ID
+                        // TODO: maybe setting the default project ID should be implicit in `requestNewProject`
+                        this.props.onHasInitialProject(false, this.props.loadingState);
+
+                        // restart as if we didn't have an initial project to load
                         this.props.onRequestNewProject();
                     }
                 );


### PR DESCRIPTION
### Resolves

This is a major step toward resolving #32
This supersedes and closes #85

### Proposed Changes

Add support for loading a project file if its file path is specified on the command line, using `minimist` to parse arguments. Use Redux state and our project state machine system to control loading the project, and migrate some of our previous manual state management (project ID and title, etc.) to use that system as well.

### Reason for Changes

Loading a project from the command line is a nice-to-have by itself, and is also a major step toward being able to double-click on a project file to load it into the app.

### Test Coverage

Tested locally with a valid project file, corrupted project file, and invalid file name.
