### PR TITLE
increase Node heap size limit & warn if too small

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3771,6 +3771,58 @@
         "xpipe": "*"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "clean": "rimraf ./dist ./static/assets",
-    "start": "mkdirp ./dist && electron-webpack dev --bail --display-error-details --env.minify=false --no-progress",
-    "compile": "mkdirp ./dist && electron-webpack --bail --display-error-details --env.minify=false --no-progress",
+    "start": "mkdirp ./dist && cross-env NODE_OPTIONS=--max-old-space-size=2560 electron-webpack dev --bail --display-error-details --env.minify=false --no-progress",
+    "compile": "mkdirp ./dist && cross-env NODE_OPTIONS=--max-old-space-size=2560 electron-webpack --bail --display-error-details --env.minify=false --no-progress",
     "fetch": "rimraf ./static/assets/ && mkdirp ./static/assets/ && node ./scripts/fetchMediaLibraryAssets.js",
     "build": "npm run build:dev",
     "build:dev": "npm run compile && npm run doBuild -- --mode=dev",
@@ -39,6 +39,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-react-intl": "^7.5.7",
     "copy-webpack-plugin": "^5.1.1",
+    "cross-env": "^7.0.3",
     "electron": "^8.2.5",
     "electron-builder": "^22.6.0",
     "electron-devtools-installer": "^3.0.0",

--- a/webpack.renderer.js
+++ b/webpack.renderer.js
@@ -1,4 +1,18 @@
 const path = require('path');
+const v8 = require('v8');
+
+const desiredHeapSizeMB = 2560; // determined experimentally
+const actualHeapSizeMB = v8.getHeapStatistics().heap_size_limit / 1024 / 1024;
+
+console.log(`Current Node heap size limit: ${actualHeapSizeMB} MB`);
+if (actualHeapSizeMB < desiredHeapSizeMB) {
+    console.warn([
+        '**********',
+        `WARNING: Node heap size limit is smaller than ${desiredHeapSizeMB} MB! Webpack may fail!`,
+        `To increase this limit set NODE_OPTIONS to include something like: --max-old-space-size=${desiredHeapSizeMB}`,
+        '**********'
+    ].join('\n'));
+}
 
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 


### PR DESCRIPTION
### Resolves

Resolves #161

### Proposed Changes

There are two changes here:
- Run `electron-webpack` with a heap size limit of 2.5GB (default in Node 12 is 2 GB)
- While building the webpack config for the render bundle, which is where the out-of-memory error occurs, check the current heap size limit and warn if it seems too small.

### Reason for Changes

I started seeing the crash described in #161 in my own development environment; I suspect it was just a matter of time. To be honest, I don't understand why it would affect some systems and not others, since the heap size limit is a property of Node and isn't directly related to the amount of RAM available to the OS.

At any rate, I ran a few tests and found that (currently) 2.5 GB is enough to avoid the crash; the heap size limit can be set to 2.5 GB by setting the `NODE_OPTIONS` environment variable so that it includes `--max-old-space-size=2560`. I added `cross-env` as a dev dependency to make it easier to set this environment variable from `package.json` on both macOS and Windows.

It's still possible to run `electron-webpack` directly (instead of through `package.json`) so I added a check in `webpack.render.js` which now warns if the heap size limit seems too small. If running `electron-webpack` by hand leads to an out-of-memory crash, hopefully this will provide a hint as to why.

Note that the out-of-memory condition, if it happens at all, usually happens while Terser is running. The Terser plugin is brought in by `electron-webpack` itself, and it's not trivial to override that part of the configuration to (for example) use UglifyJS instead.

### Test Coverage

Tested by hand on my development systems. CI will also effectively test this by building the PR.

To force the out-of-memory condition for the sake of comparison, change `--max-old-space-size=2560` to something smaller, like `--max-old-space-size=560`, and try to compile.
