### PR TITLE
Show privacy policy inside app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 # File types which we know are binary
 
 # Prefer LF for most file types
+*.css text eol=lf
 *.htm text eol=lf
 *.html text eol=lf
 *.js text eol=lf

--- a/src/main/ScratchDesktopTelemetry.js
+++ b/src/main/ScratchDesktopTelemetry.js
@@ -93,16 +93,16 @@ class ScratchDesktopTelemetry {
 // make a singleton so it's easy to share across both Electron processes
 const scratchDesktopTelemetrySingleton = new ScratchDesktopTelemetry();
 
+// `handle` works with `invoke`
+ipcMain.handle('getTelemetryDidOptIn', () =>
+    scratchDesktopTelemetrySingleton.didOptIn
+);
+// `on` works with `sendSync` (and `send`)
 ipcMain.on('getTelemetryDidOptIn', event => {
     event.returnValue = scratchDesktopTelemetrySingleton.didOptIn;
 });
 ipcMain.on('setTelemetryDidOptIn', (event, arg) => {
     scratchDesktopTelemetrySingleton.didOptIn = arg;
-    event.returnValue = null;
-});
-ipcMain.on('clearTelemetryDidOptIn', event => {
-    scratchDesktopTelemetrySingleton.clearDidOptIn();
-    event.returnValue = null;
 });
 ipcMain.on('projectDidLoad', (event, arg) => {
     scratchDesktopTelemetrySingleton.projectDidLoad(arg);

--- a/src/main/ScratchDesktopTelemetry.js
+++ b/src/main/ScratchDesktopTelemetry.js
@@ -36,6 +36,9 @@ class ScratchDesktopTelemetry {
     set didOptIn (value) {
         this._telemetryClient.didOptIn = value;
     }
+    clearDidOptIn () {
+        this._telemetryClient.clearDidOptIn();
+    }
 
     appWasOpened () {
         this._telemetryClient.addEvent('app::open', {...EVENT_TEMPLATE, ...APP_INFO});
@@ -95,6 +98,11 @@ ipcMain.on('getTelemetryDidOptIn', event => {
 });
 ipcMain.on('setTelemetryDidOptIn', (event, arg) => {
     scratchDesktopTelemetrySingleton.didOptIn = arg;
+    event.returnValue = null;
+});
+ipcMain.on('clearTelemetryDidOptIn', event => {
+    scratchDesktopTelemetrySingleton.clearDidOptIn();
+    event.returnValue = null;
 });
 ipcMain.on('projectDidLoad', (event, arg) => {
     scratchDesktopTelemetrySingleton.projectDidLoad(arg);

--- a/src/main/ScratchDesktopTelemetry.js
+++ b/src/main/ScratchDesktopTelemetry.js
@@ -36,9 +36,6 @@ class ScratchDesktopTelemetry {
     set didOptIn (value) {
         this._telemetryClient.didOptIn = value;
     }
-    clearDidOptIn () {
-        this._telemetryClient.clearDidOptIn();
-    }
 
     appWasOpened () {
         this._telemetryClient.addEvent('app::open', {...EVENT_TEMPLATE, ...APP_INFO});

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -200,6 +200,9 @@ const createWindow = ({search = null, url = 'index.html', ...browserWindowOption
 
     const fullUrl = makeFullUrl(url, search);
     window.loadURL(fullUrl);
+    window.once('ready-to-show', () => {
+        webContents.send('ready-to-show');
+    });
 
     return window;
 };
@@ -396,6 +399,10 @@ app.on('ready', () => {
 
 ipcMain.on('open-about-window', () => {
     _windows.about.show();
+});
+
+ipcMain.on('open-privacy-policy-window', () => {
+    _windows.privacy.show();
 });
 
 // start loading initial project data before the GUI needs it so the load seems faster

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -210,6 +210,17 @@ const createAboutWindow = () => {
     return window;
 };
 
+const createPrivacyWindow = () => {
+    const window = createWindow({
+        width: _windows.main.width * 0.8,
+        height: _windows.main.height * 0.8,
+        parent: _windows.main,
+        search: 'route=privacy',
+        title: 'Scratch Desktop Privacy Policy'
+    });
+    return window;
+};
+
 const getIsProjectSave = downloadItem => {
     switch (downloadItem.getMimeType()) {
     case 'application/x.scratch.sb3':
@@ -370,6 +381,11 @@ app.on('ready', () => {
     _windows.about.on('close', event => {
         event.preventDefault();
         _windows.about.hide();
+    });
+    _windows.privacy = createPrivacyWindow();
+    _windows.privacy.on('close', event => {
+        event.preventDefault();
+        _windows.privacy.hide();
     });
 });
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,4 @@
-import {BrowserWindow, Menu, app, dialog, ipcMain, systemPreferences} from 'electron';
+import {BrowserWindow, Menu, app, dialog, ipcMain, shell, systemPreferences} from 'electron';
 import fs from 'fs-extra';
 import path from 'path';
 import {URL} from 'url';
@@ -191,6 +191,11 @@ const createWindow = ({search = null, url = 'index.html', ...browserWindowOption
             event.preventDefault();
             webContents.openDevTools({mode: 'detach', activate: true});
         }
+    });
+
+    webContents.on('new-window', (event, newWindowUrl) => {
+        shell.openExternal(newWindowUrl);
+        event.preventDefault();
     });
 
     const fullUrl = makeFullUrl(url, search);

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -185,6 +185,9 @@ class TelemetryClient {
     set didOptIn (value) {
         this._store.set('optIn', !!value);
     }
+    clearDidOptIn () {
+        this._store.delete('optIn');
+    }
 
     /**
      * Semi-persistent unique ID for this client

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -185,9 +185,6 @@ class TelemetryClient {
     set didOptIn (value) {
         this._store.set('optIn', !!value);
     }
-    clearDidOptIn () {
-        this._store.delete('optIn');
-    }
 
     /**
      * Semi-persistent unique ID for this client

--- a/src/renderer/about.css
+++ b/src/renderer/about.css
@@ -5,6 +5,14 @@ html, body {
     font-weight: bolder;
 }
 
+a:active, a:hover, a:link, a:visited {
+    color: currentColor;
+}
+
+a:active, a:hover {
+    filter: brightness(0.9);
+}
+
 .aboutBox {
     margin: 0;
     position: absolute;
@@ -24,4 +32,8 @@ html, body {
 
 .aboutDetails {
     font-size: x-small;
+}
+
+.aboutFooter {
+    font-size: small;
 }

--- a/src/renderer/about.css
+++ b/src/renderer/about.css
@@ -1,0 +1,26 @@
+html, body {
+    color: white;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: bolder;
+}
+
+.aboutBox {
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.aboutLogo {
+    max-width: 10rem;
+    max-height: 10rem;
+}
+
+.aboutText {
+    margin: 1.5rem;
+}
+
+.aboutDetails {
+    font-size: x-small;
+}

--- a/src/renderer/about.css
+++ b/src/renderer/about.css
@@ -1,4 +1,5 @@
 html, body {
+    background-color: #4D97FF;
     color: white;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-weight: bolder;

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -25,9 +25,9 @@ const AboutElement = () => (
             </tbody></table>
             <p className={styles.aboutFooter}>
                 <a
-                    // The `href` attribute causes link styling to be applied. The value doesn't really matter but using a
-                    // reasonable value might make testing easier, or at least makes the HTML more readable. The `onClick`
-                    // function actually handles opening the privacy policy window.
+                    // The `href` attribute causes link styling to be applied. The value doesn't really matter but
+                    // using a reasonable value might make testing easier, or at least makes the HTML more readable.
+                    // The `onClick` function actually handles opening the privacy policy window.
                     href="./index.html?route=privacy"
                     onClick={showPrivacyPolicy}
                 >View the Privacy Policy...</a>

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -1,9 +1,20 @@
+import {ipcRenderer} from 'electron';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {productName, version} from '../../package.json';
 
 import logo from '../icon/ScratchDesktop.svg';
 import styles from './about.css';
+
+// don't actually follow the link in the `href` attribute
+// instead, tell the main process to open the privacy policy window
+const showPrivacyPolicy = event => {
+    if (event) {
+        event.preventDefault();
+    }
+    ipcRenderer.send('open-privacy-policy-window');
+    return false;
+};
 
 const AboutElement = () => (
     <div className={styles.aboutBox}>
@@ -14,15 +25,24 @@ const AboutElement = () => (
         /></div>
         <div className={styles.aboutText}>
             <h2>{productName}</h2>
-            <div>Version {version}</div>
-            <table className={styles.aboutDetails}>
+            Version {version}
+            <table className={styles.aboutDetails}><tbody>
                 {
-                    ['Electron', 'Chrome'].map(component => {
+                    ['Electron', 'Chrome', 'Node'].map(component => {
                         const componentVersion = process.versions[component.toLowerCase()];
                         return <tr key={component}><td>{component}</td><td>{componentVersion}</td></tr>;
                     })
                 }
-            </table>
+            </tbody></table>
+            <p className={styles.aboutFooter}>
+                <a
+                    // The `href` attribute causes link styling to be applied. The value doesn't really matter but using a
+                    // reasonable value might make testing easier, or at least makes the HTML more readable. The `onClick`
+                    // function actually handles opening the privacy policy window.
+                    href="./index.html?route=privacy"
+                    onClick={showPrivacyPolicy}
+                >View the Privacy Policy...</a>
+            </p>
         </div>
     </div>
 );

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -1,20 +1,10 @@
-import {ipcRenderer} from 'electron';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {productName, version} from '../../package.json';
 
 import logo from '../icon/ScratchDesktop.svg';
 import styles from './about.css';
-
-// don't actually follow the link in the `href` attribute
-// instead, tell the main process to open the privacy policy window
-const showPrivacyPolicy = event => {
-    if (event) {
-        event.preventDefault();
-    }
-    ipcRenderer.send('open-privacy-policy-window');
-    return false;
-};
+import showPrivacyPolicy from './showPrivacyPolicy';
 
 const AboutElement = () => (
     <div className={styles.aboutBox}>

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -5,7 +5,6 @@ import {productName, version} from '../../package.json';
 import logo from '../icon/ScratchDesktop.svg';
 import styles from './about.css';
 
-// TODO: localization?
 const AboutElement = () => (
     <div className={styles.aboutBox}>
         <div><img

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -3,33 +3,20 @@ import ReactDOM from 'react-dom';
 import {productName, version} from '../../package.json';
 
 import logo from '../icon/ScratchDesktop.svg';
+import styles from './about.css';
 
 // TODO: localization?
 const AboutElement = () => (
-    <div
-        style={{
-            color: 'white',
-            fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
-            fontWeight: 'bolder',
-            margin: 0,
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)'
-        }}
-    >
+    <div className={styles.aboutBox}>
         <div><img
             alt={`${productName} icon`}
             src={logo}
-            style={{
-                maxWidth: '10rem',
-                maxHeight: '10rem'
-            }}
+            className={styles.aboutLogo}
         /></div>
-        <div style={{margin: '1.5rem'}}>
+        <div className={styles.aboutText}>
             <h2>{productName}</h2>
             <div>Version {version}</div>
-            <table style={{fontSize: 'x-small'}}>
+            <table className={styles.aboutDetails}>
                 {
                     ['Electron', 'Chrome'].map(component => {
                         const componentVersion = process.versions[component.toLowerCase()];

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -3,7 +3,6 @@ import {productName, version} from '../../package.json';
 
 import logo from '../icon/ScratchDesktop.svg';
 import styles from './about.css';
-import showPrivacyPolicy from './showPrivacyPolicy';
 
 const AboutElement = () => (
     <div className={styles.aboutBox}>
@@ -23,15 +22,6 @@ const AboutElement = () => (
                     })
                 }
             </tbody></table>
-            <p className={styles.aboutFooter}>
-                <a
-                    // The `href` attribute causes link styling to be applied. The value doesn't really matter but
-                    // using a reasonable value might make testing easier, or at least makes the HTML more readable.
-                    // The `onClick` function actually handles opening the privacy policy window.
-                    href="./index.html?route=privacy"
-                    onClick={showPrivacyPolicy}
-                >View the Privacy Policy...</a>
-            </p>
         </div>
     </div>
 );

--- a/src/renderer/about.jsx
+++ b/src/renderer/about.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {productName, version} from '../../package.json';
 
 import logo from '../icon/ScratchDesktop.svg';
@@ -37,5 +36,4 @@ const AboutElement = () => (
     </div>
 );
 
-const appTarget = document.getElementById('app');
-ReactDOM.render(<AboutElement />, appTarget);
+export default <AboutElement />;

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -131,7 +131,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                         onClick: () => showPrivacyPolicy()
                     },
                     {
-                        title: 'Telemetry Settings',
+                        title: 'Data Settings',
                         onClick: () => this.props.onTelemetrySettingsClicked()
                     }
                 ]}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -116,7 +116,23 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 canSave={false}
                 isScratchDesktop
                 showTelemetryModal={shouldShowTelemetryModal}
-                onClickAbout={this.handleClickAbout}
+                onClickAbout={[
+                    {
+                        title: 'About',
+                        onClick: () => this.handleClickAbout()
+                    },
+                    {
+                        title: 'Privacy Policy',
+                        onClick: () => showPrivacyPolicy()
+                    },
+                    {
+                        title: 'Telemetry Settings',
+                        onClick: () => {
+                            // set to null (non-Boolean) to cause app to ask again
+                            ipcRenderer.sendSync('clearTelemetryDidOptIn');
+                        }
+                    }
+                ]}
                 onProjectTelemetryEvent={this.handleProjectTelemetryEvent}
                 onShowPrivacyPolicy={showPrivacyPolicy}
                 onStorageInit={this.handleStorageInit}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -3,7 +3,6 @@ import bindAll from 'lodash.bindall';
 import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
 import {compose} from 'redux';
 import GUI from 'scratch-gui/src/index';
@@ -181,4 +180,4 @@ const WrappedGui = compose(
     ScratchDesktopHOC
 )(GUI);
 
-ReactDOM.render(<WrappedGui />, appTarget);
+export default <WrappedGui />;

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -99,15 +99,18 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         }
         handleTelemetryModalOptIn () {
             ipcRenderer.send('setTelemetryDidOptIn', true);
+            this.forceUpdate();
         }
         handleTelemetryModalOptOut () {
             ipcRenderer.send('setTelemetryDidOptIn', false);
+            this.forceUpdate();
         }
         handleUpdateProjectTitle (newTitle) {
             this.setState({projectTitle: newTitle});
         }
         render () {
-            const shouldShowTelemetryModal = (typeof ipcRenderer.sendSync('getTelemetryDidOptIn') !== 'boolean');
+            const currentTelemetryState = ipcRenderer.sendSync('getTelemetryDidOptIn');
+            const shouldShowTelemetryModal = (typeof currentTelemetryState !== 'boolean');
 
             const childProps = omit(this.props, Object.keys(ScratchDesktopComponent.propTypes));
 
@@ -116,6 +119,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 canModifyCloudData={false}
                 canSave={false}
                 isScratchDesktop
+                isTelemetryEnabled={currentTelemetryState}
                 showTelemetryModal={shouldShowTelemetryModal}
                 onClickAbout={[
                     {

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -20,7 +20,8 @@ import {
 } from 'scratch-gui/src/reducers/project-state';
 import {
     openLoadingProject,
-    closeLoadingProject
+    closeLoadingProject,
+    openTelemetryModal
 } from 'scratch-gui/src/reducers/modals';
 
 import ElectronStorageHelper from '../common/ElectronStorageHelper';
@@ -127,10 +128,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                     },
                     {
                         title: 'Telemetry Settings',
-                        onClick: () => {
-                            // set to null (non-Boolean) to cause app to ask again
-                            ipcRenderer.sendSync('clearTelemetryDidOptIn');
-                        }
+                        onClick: () => this.props.onTelemetrySettingsClicked()
                     }
                 ]}
                 onProjectTelemetryEvent={this.handleProjectTelemetryEvent}
@@ -154,6 +152,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         onLoadingCompleted: PropTypes.func,
         onLoadingStarted: PropTypes.func,
         onRequestNewProject: PropTypes.func,
+        onTelemetrySettingsClicked: PropTypes.func,
         vm: PropTypes.instanceOf(VM).isRequired
     };
     const mapStateToProps = state => {
@@ -182,7 +181,8 @@ const ScratchDesktopHOC = function (WrappedComponent) {
             const canSaveToServer = false;
             return dispatch(onLoadedProject(loadingState, canSaveToServer, loadSuccess));
         },
-        onRequestNewProject: () => dispatch(requestNewProject(false))
+        onRequestNewProject: () => dispatch(requestNewProject(false)),
+        onTelemetrySettingsClicked: () => dispatch(openTelemetryModal())
     });
 
     return connect(mapStateToProps, mapDispatchToProps)(ScratchDesktopComponent);

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -28,12 +28,8 @@ import ElectronStorageHelper from '../common/ElectronStorageHelper';
 
 import styles from './app.css';
 
-// Register "base" page view
-// analytics.pageview('/');
-
 const appTarget = document.getElementById('app');
-appTarget.className = styles.app || 'app'; // TODO
-document.body.appendChild(appTarget);
+appTarget.className = styles.app || 'app';
 
 GUI.setAppElement(appTarget);
 
@@ -117,6 +113,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
             return (<WrappedComponent
                 canEditTitle
                 canModifyCloudData={false}
+                canSave={false}
                 isScratchDesktop
                 showTelemetryModal={shouldShowTelemetryModal}
                 onClickLogo={this.handleClickLogo}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -1,4 +1,4 @@
-import {ipcRenderer, remote, shell} from 'electron';
+import {ipcRenderer, remote} from 'electron';
 import bindAll from 'lodash.bindall';
 import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
@@ -28,12 +28,6 @@ import ElectronStorageHelper from '../common/ElectronStorageHelper';
 
 import styles from './app.css';
 
-// override window.open so that it uses the OS's default browser, not an electron browser
-window.open = function (url, target) {
-    if (target === '_blank') {
-        shell.openExternal(url);
-    }
-};
 // Register "base" page view
 // analytics.pageview('/');
 

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -26,6 +26,7 @@ import {
 
 import ElectronStorageHelper from '../common/ElectronStorageHelper';
 
+import showPrivacyPolicy from './showPrivacyPolicy';
 import styles from './app.css';
 
 const appTarget = document.getElementById('app');
@@ -118,6 +119,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 showTelemetryModal={shouldShowTelemetryModal}
                 onClickAbout={this.handleClickAbout}
                 onProjectTelemetryEvent={this.handleProjectTelemetryEvent}
+                onShowPrivacyPolicy={showPrivacyPolicy}
                 onStorageInit={this.handleStorageInit}
                 onTelemetryModalOptIn={this.handleTelemetryModalOptIn}
                 onTelemetryModalOptOut={this.handleTelemetryModalOptOut}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -84,7 +84,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
         componentWillUnmount () {
             ipcRenderer.removeListener('setTitleFromSave', this.handleSetTitleFromSave);
         }
-        handleClickLogo () {
+        handleClickAbout () {
             ipcRenderer.send('open-about-window');
         }
         handleProjectTelemetryEvent (event, metadata) {
@@ -116,7 +116,7 @@ const ScratchDesktopHOC = function (WrappedComponent) {
                 canSave={false}
                 isScratchDesktop
                 showTelemetryModal={shouldShowTelemetryModal}
-                onClickLogo={this.handleClickLogo}
+                onClickAbout={this.handleClickAbout}
                 onProjectTelemetryEvent={this.handleProjectTelemetryEvent}
                 onStorageInit={this.handleStorageInit}
                 onTelemetryModalOptIn={this.handleTelemetryModalOptIn}

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -1,5 +1,14 @@
-// this is an async import so that it doesn't block the first render
-// index.html contains a loading/splash screen which will display while this import loads
+// This file does async imports of the heavy JSX, especially app.jsx, to avoid blocking the first render.
+// The main index.html just contains a loading/splash screen which will display while this import loads.
+
+import {ipcRenderer} from 'electron';
+
+ipcRenderer.on('ready-to-show', () => {
+    // Start without any element in focus, otherwise the first link starts with focus and shows an orange box.
+    // We shouldn't disable that box or the focus behavior in case someone wants or needs to navigate that way.
+    // This seems like a hack... maybe there's some better way to do avoid any element starting with focus?
+    document.activeElement.blur();
+});
 
 const route = new URLSearchParams(window.location.search).get('route') || 'app';
 switch (route) {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -9,4 +9,7 @@ case 'app':
 case 'about':
     import('./about.jsx'); // eslint-disable-line no-unused-expressions
     break;
+case 'privacy':
+    import('./privacy.jsx');
+    break;
 }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -3,6 +3,8 @@
 
 import {ipcRenderer} from 'electron';
 
+import ReactDOM from 'react-dom';
+
 ipcRenderer.on('ready-to-show', () => {
     // Start without any element in focus, otherwise the first link starts with focus and shows an orange box.
     // We shouldn't disable that box or the focus behavior in case someone wants or needs to navigate that way.
@@ -11,14 +13,21 @@ ipcRenderer.on('ready-to-show', () => {
 });
 
 const route = new URLSearchParams(window.location.search).get('route') || 'app';
+let routeModulePromise;
 switch (route) {
 case 'app':
-    import('./app.jsx'); // eslint-disable-line no-unused-expressions
+    routeModulePromise = import('./app.jsx');
     break;
 case 'about':
-    import('./about.jsx'); // eslint-disable-line no-unused-expressions
+    routeModulePromise = import('./about.jsx');
     break;
 case 'privacy':
-    import('./privacy.jsx');
+    routeModulePromise = import('./privacy.jsx');
     break;
 }
+
+routeModulePromise.then(routeModule => {
+    const appTarget = document.getElementById('app');
+    const routeElement = routeModule.default;
+    ReactDOM.render(routeElement, appTarget);
+});

--- a/src/renderer/privacy.css
+++ b/src/renderer/privacy.css
@@ -1,0 +1,14 @@
+html, body {
+    background-color: #4D97FF;
+    color: white;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: normal;
+    line-height: 150%;
+}
+
+.privacyBox {
+    background-color: white;
+    color: #575e75;
+    margin: 3rem;
+    padding: 2rem 3rem;
+}

--- a/src/renderer/privacy.jsx
+++ b/src/renderer/privacy.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import styles from './privacy.css';
 
@@ -58,5 +57,4 @@ const PrivacyElement = () => (
     </div>
 );
 
-const appTarget = document.getElementById('app');
-ReactDOM.render(<PrivacyElement />, appTarget);
+export default <PrivacyElement />;

--- a/src/renderer/privacy.jsx
+++ b/src/renderer/privacy.jsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 
 import styles from './privacy.css';
 
-// TODO: localization?
 const PrivacyElement = () => (
     <div className={styles.privacyBox}>
         <h1>Privacy Policy</h1>
@@ -11,7 +10,11 @@ const PrivacyElement = () => (
             We understand how important privacy is to our community, especially children and their parents. We wrote
             this privacy policy to explain what information we collect through the Scratch application (the
             &ldquo;App&rdquo;), how we use it, and what we&apos;re doing to keep it safe. If you have any questions
-            regarding this privacy policy, you can <a href="https://scratch.mit.edu/contact-us">contact us</a>.
+            regarding this privacy policy, you can <a
+                href="https://scratch.mit.edu/contact-us/"
+                target="_blank"
+                rel="noopener noreferrer"
+            >contact us</a>.
         </p>
         <h2>What information does the App collect?</h2>
         <p>

--- a/src/renderer/privacy.jsx
+++ b/src/renderer/privacy.jsx
@@ -5,55 +5,230 @@ import styles from './privacy.css';
 const PrivacyElement = () => (
     <div className={styles.privacyBox}>
         <h1>Privacy Policy</h1>
+        <i>The Scratch Privacy Policy was last updated: October 5, 2020</i>
         <p>
-            We understand how important privacy is to our community, especially children and their parents. We wrote
-            this privacy policy to explain what information we collect through the Scratch application (the
-            &ldquo;App&rdquo;), how we use it, and what we&apos;re doing to keep it safe. If you have any questions
-            regarding this privacy policy, you can <a
+            The Scratch Foundation (&ldquo;Scratch&rdquo;, &ldquo;we&rdquo; or &ldquo;us&rdquo;) understands how
+            important privacy is to our community. We wrote this Privacy Policy to explain what Personal Information
+            (&ldquo;Information&rdquo;) we collect through our offline editor (the &ldquo;<a
+                href="https://scratch.mit.edu/download"
+                target="_blank"
+                rel="noopener noreferrer"
+            >Scratch App</a>&rdquo;), how we use, process, and share it, and what we&apos;re doing to keep it safe. It
+            also tells you about your rights and choices with respect to your Personal Information, and how you can <a
                 href="https://scratch.mit.edu/contact-us/"
                 target="_blank"
                 rel="noopener noreferrer"
-            >contact us</a>.
+            >contact us</a> if you have any questions or concerns.
         </p>
-        <h2>What information does the App collect?</h2>
+        <h2>What Information Does Scratch Collect About Me?</h2>
         <p>
-            The Scratch Team is always looking to better understand how Scratch is used around the world. To help
-            support this effort, Scratch only collects anonymous usage information from the Scratch App. This
-            information does not include any Personal Information. For purposes of this Privacy Policy, &ldquo;Personal
-            Information&rdquo; means any information relating to an identified or identifiable individual.
+            For the purpose of this Privacy Policy, &ldquo;Information&rdquo; means any information relating to an
+            identified or identifiable individual. The Scratch App automatically collects and stores locally the
+            following Information through its telemetry system: the title of your project in text form, language
+            setting, time zone and events related to your use of the Scratch App (namely when the Scratch App was
+            opened and closed, if a project file has been loaded or saved, or if a new project is created). If you
+            choose to turn on the telemetry sharing feature, the Scratch App will transmit this information to Scratch.
+            Projects created in the Scratch App are not transmitted to or accessible by Scratch.
         </p>
-        <p>
-            The anonymous usage information we collect includes data about what parts of the app you use and basic
-            information about your network that allows us to roughly estimate what part of the world you are located
-            in. We also may collect general information about the device that you are using, such as make, model,
-            operating system and screen resolution. We do not collect device identifiers, such as advertising IDs, MAC
-            addresses, or IP addresses. We do not associate any of this information with an identified or identifiable
-            individual.
-        </p>
-        <h2>How does the Scratch Team use the information it collects?</h2>
+        <h2>How Does Scratch Use My Information?</h2>
+        <p>We use this Information for the following purposes:</p>
         <ul>
             <li>
-                We may use anonymous usage information in research studies intended to improve our understanding of how
-                people learn with Scratch. The results of this research are shared with educators and researchers
-                through conferences, journals, and other publications.
+                <b>Analytics and Improving the Scratch App</b> - We use the Information to analyze use of the Scratch
+                App and to enhance your learning experience on the Scratch App.
             </li>
             <li>
-                We analyze the information to understand and improve Scratch, such as determining which elements are
-                most used and how long users spend in the app.
+                <b>Academic and Scientific Research</b> - We de-identify and aggregate Information for statistical
+                analysis in the context of scientific and academic research. For example, to help us understand how
+                people learn through the Scratch App and how we can enhance learning tools for young people. The
+                results of such research are shared with educators and researchers through conferences, journals, and
+                other academic or scientific publications. You can find out more on our <a
+                    href="https://scratch.mit.edu/research"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >Research page</a>.
             </li>
             <li>
-                We will never share anonymous usage data with any other person, company, or organization, except:
-                <ul>
-                    <li>
-                        As required to comply with our obligations under the law
-                    </li>
-                    <li>
-                        For technical reasons, if we are required to transfer the data on our servers to another
-                        location or organization
-                    </li>
-                </ul>
+                <b>Legal</b> - We may use your Information to enforce our <a
+                    href="https://scratch.mit.edu/terms_of_use"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >Terms of Use</a>, to defend our legal rights, and to comply with our legal obligations and internal
+                policies. We may do this by analyzing your use of the Scratch App.
             </li>
         </ul>
+        <h2>What Are The Legal Grounds For Processing Your Information?</h2>
+        <p>
+            If you are located in the European Economic Area, the United Kingdom or Switzerland, we only process your
+            Information based on a valid legal ground. A &ldquo;legal ground&rdquo; is a reason that justifies our use
+            of your Information. In this case, we or a third party have a legitimate interest in using your Information
+            (if you choose to allow the Scratch App to send the Scratch team your Information) to create, analyze and
+            share your aggregated or de-identified Information for research purposes, to analyze and enhance your
+            learning experience on the Scratch App and otherwise ensure and improve the safety, security, and
+            performance of the Scratch App. We only rely on our or a third party’s legitimate interests to process your
+            Information when these interests are not overridden by your rights and interests.
+        </p>
+        <h2>How Does Scratch Share My Information?</h2>
+        <p>
+            We disclose information that we collect through the Scratch App to third parties in the following
+            circumstances:
+        </p>
+        <ul>
+            <li>
+                <b>Service Providers</b> - To third parties who provide services such as website hosting, data
+                analysis, Information technology and related infrastructure provisions, customer service, email
+                delivery, and other services.
+            </li>
+            <li>
+                <b>Academic and Scientific Research</b> - To research institutions, such as the Massachusetts Institute
+                of Technology (MIT), to learn about how our users learn through the Scratch App and develop new
+                learning tools. The results of this research or the statistical analysis may be shared through
+                conferences, journals, and other publications.
+            </li>
+            <li>
+                <b>Merger</b> - To a potential or actual acquirer, successor, or assignee as part of any
+                reorganization, merger, sale, joint venture, assignment, transfer, or other disposition of all or any
+                portion of our organization or assets. You will have the opportunity to opt out of any such transfer if
+                the new entity&apos;s planned processing of your Information differs materially from that set forth in
+                this Privacy Policy.
+            </li>
+            <li>
+                <b>Legal</b> - If required to do so by law or in the good faith belief that such action is appropriate:
+                (a) under applicable law, including laws outside your country of residence; (b) to comply with legal
+                process; (c) to respond to requests from public and government authorities, such as school, school
+                districts, and law enforcement, including public and government authorities outside your country of
+                residence; (d) to enforce our terms and conditions; (e) to protect our operations or those of any of
+                our affiliates; (f) to protect our rights, privacy, safety, or property, and/or that of our affiliates,
+                you, or others; and (g) to allow us to pursue available remedies or limit the damages that we may
+                sustain.
+            </li>
+        </ul>
+        <h2>Children and Student Privacy</h2>
+        <p>
+            The Scratch Foundation is a 501(c)(3) nonprofit organization. As such, the Children&apos;s Online Privacy
+            Protection Act (COPPA) does not apply to Scratch. Nevertheless, Scratch takes children&apos;s privacy
+            seriously. Scratch collects only minimal information from its users, and only uses and discloses
+            information to provide the services and for limited other purposes, such as research, as described in this
+            Privacy Policy.
+        </p>
+        <p>
+            Scratch does not collect information from a student&apos;s education record, as defined by the Family
+            Educational Rights and Privacy Act (FERPA). Scratch does not disclose information of students to any third
+            parties except as described in this Privacy Policy.
+        </p>
+        <h2>Your Data Protection Rights (EEA)</h2>
+        <p>
+            If you are located in the European Economic Area, the United Kingdom or Switzerland, you have certain
+            rights in relation to your Information:
+        </p>
+        <ul>
+            <li>
+                <b>Access, Correction and Data Portability</b> - You may ask for an overview of the Information we
+                process about you and to receive a copy of your Information. You also have the right to request to
+                correct incomplete, inaccurate or outdated Information. To the extent required by applicable law, you
+                may request us to provide your Information to another company.
+            </li>
+            <li>
+                <b>Objection</b> – You may object to (this means &ldquo;ask us to stop&rdquo;) any use of your
+                Information that is not (i) processed to comply with a legal obligation, (ii) necessary to do what is
+                provided in a contract between Scratch and you, or (iii) if we have a compelling reason to do so (such
+                as, to ensure safety and security in our online community). If you do object, we will work with you to
+                find a reasonable solution.
+            </li>
+            <li>
+                <b>Deletion</b> - You may also request the deletion of your Information, as permitted under applicable
+                law. This applies, for instance, where your Information is outdated or the processing is not necessary
+                or is unlawful; where you withdraw your consent to our processing based on such consent; or where you
+                have objected to our processing. In some situations, we may need to retain your Information due to
+                legal obligations or for litigation purposes. If you want to have all of your Information removed from
+                our servers, please contact <a
+                    href="mailto:help@scratch.mit.edu"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >help@scratch.mit.edu</a> for assistance.
+            </li>
+            <li>
+                <b>Restriction Of Processing</b> - You may request that we restrict processing of your Information
+                while we are processing a request relating to (i) the accuracy of your Information, (ii) the lawfulness
+                of the processing of your Information, or (iii) our legitimate interests to process this Information.
+                You may also request that we restrict processing of your Information if you wish to use the Information
+                for litigation purposes.
+            </li>
+            <li>
+                <b>Withdrawal Of Consent</b> – Where we rely on consent for the processing of your Information, you
+                have the right to withdraw it at any time and free of charge. When you do so, this will not affect the
+                lawfulness of the processing before your consent withdrawal.
+            </li>
+        </ul>
+        <p>
+            In addition to the above-mentioned rights, you also have the right to lodge a complaint with a competent
+            supervisory authority subject to applicable law. However, there are exceptions and limitations to each of
+            these rights. We may, for example, refuse to act on a request if the request is manifestly unfounded or
+            excessive, or if the request is likely to adversely affect the rights and freedoms of others, prejudice the
+            execution or enforcement of the law, interfere with pending or future litigation, or infringe applicable
+            law. To submit a request to exercise your rights, please contact <a
+                href="mailto:help@scratch.mit.edu"
+                target="_blank"
+                rel="noopener noreferrer"
+            >help@scratch.mit.edu</a> for assistance.
+        </p>
+        <h2>Data Retention</h2>
+        <p>
+            We take measures to delete your Information or keep it in a form that does not allow you to be identified
+            when this Information is no longer necessary for the purposes for which we process it, unless we are
+            required by law to keep this Information for a longer period. When determining the retention period, we
+            take into account various criteria, such as the type of services requested by or provided to you, the
+            nature and length of our relationship with you, possible re-enrollment with our services, the impact on the
+            services we provide to you if we delete some Information from or about you, mandatory retention periods
+            provided by law and the statute of limitations.
+        </p>
+        <h2>How Does Scratch Protect My Information?</h2>
+        <p>
+            Scratch has in place administrative, physical, and technical procedures that are intended to protect the
+            Information we collect on the Scratch App against accidental or unlawful destruction, accidental loss,
+            unauthorized alteration, unauthorized disclosure or access, misuse, and any other unlawful form of
+            processing of the Information. However, as effective as these measures are, no security system is
+            impenetrable. We cannot completely guarantee the security of our databases, nor can we guarantee that the
+            Information you supply will not be intercepted while being transmitted to us over the Internet.
+        </p>
+        <h2>International Data Transfer</h2>
+        <p>
+            We may transfer your Information to countries other than the country where you are located, including to
+            the U.S. (where our Scratch servers are located) or any other country in which we or our service providers
+            maintain facilities. If you are located in the European Economic Area, the United Kingdom or Switzerland,
+            or other regions with laws governing data collection and use that may differ from U.S. law, please note
+            that we may transfer your Information to a country and jurisdiction that does not have the same data
+            protection laws as your jurisdiction. We apply appropriate safeguards to the Information processed and
+            transferred on our behalf. Please contact us for more information on the safeguards used.
+        </p>
+        <h2>Notifications Of Changes To The Privacy Policy</h2>
+        <p>
+            We review our Privacy Policy on a periodic basis, and we may modify our policies as appropriate. We will
+            notify you of any material changes. We encourage you to review our Privacy Policy on a regular basis. The
+            &ldquo;Last Updated&rdquo; date at the top of this page indicates when this Privacy Policy was last
+            revised. Your continued use of the Scratch App following these changes means that you accept the revised
+            Privacy Policy.
+        </p>
+        <h2>Contact Us</h2>
+        <p>
+            The Scratch Foundation is the entity responsible for the processing of your Information. If you have any
+            questions about this Privacy Policy, or if you would like to exercise your rights to your Information, you
+            may contact us at <a
+                href="mailto:help@scratch.mit.edu"
+                target="_blank"
+                rel="noopener noreferrer"
+            >help@scratch.mit.edu</a> or via mail at:
+        </p>
+        <div className="vcard">
+            <div className="org">Scratch Foundation</div>
+            <div className="fn">ATTN: Privacy Policy</div>
+            <div className="adr">
+                <div className="street-address">201 South Street</div>
+                <span className="locality">Boston</span>, <span className="region">MA</span> <span
+                    className="postal-code"
+                >02111</span>
+            </div>
+        </div>
     </div>
 );
 

--- a/src/renderer/privacy.jsx
+++ b/src/renderer/privacy.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import styles from './privacy.css';
+
+// TODO: localization?
+const PrivacyElement = () => (
+    <div className={styles.privacyBox}>
+        <h1>Privacy Policy</h1>
+        <p>
+            We understand how important privacy is to our community, especially children and their parents. We wrote
+            this privacy policy to explain what information we collect through the Scratch application (the
+            &ldquo;App&rdquo;), how we use it, and what we&apos;re doing to keep it safe. If you have any questions
+            regarding this privacy policy, you can <a href="https://scratch.mit.edu/contact-us">contact us</a>.
+        </p>
+        <h2>What information does the App collect?</h2>
+        <p>
+            The Scratch Team is always looking to better understand how Scratch is used around the world. To help
+            support this effort, Scratch only collects anonymous usage information from the Scratch App. This
+            information does not include any Personal Information. For purposes of this Privacy Policy, &ldquo;Personal
+            Information&rdquo; means any information relating to an identified or identifiable individual.
+        </p>
+        <p>
+            The anonymous usage information we collect includes data about what parts of the app you use and basic
+            information about your network that allows us to roughly estimate what part of the world you are located
+            in. We also may collect general information about the device that you are using, such as make, model,
+            operating system and screen resolution. We do not collect device identifiers, such as advertising IDs, MAC
+            addresses, or IP addresses. We do not associate any of this information with an identified or identifiable
+            individual.
+        </p>
+        <h2>How does the Scratch Team use the information it collects?</h2>
+        <ul>
+            <li>
+                We may use anonymous usage information in research studies intended to improve our understanding of how
+                people learn with Scratch. The results of this research are shared with educators and researchers
+                through conferences, journals, and other publications.
+            </li>
+            <li>
+                We analyze the information to understand and improve Scratch, such as determining which elements are
+                most used and how long users spend in the app.
+            </li>
+            <li>
+                We will never share anonymous usage data with any other person, company, or organization, except:
+                <ul>
+                    <li>
+                        As required to comply with our obligations under the law
+                    </li>
+                    <li>
+                        For technical reasons, if we are required to transfer the data on our servers to another
+                        location or organization
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+);
+
+const appTarget = document.getElementById('app');
+ReactDOM.render(<PrivacyElement />, appTarget);

--- a/src/renderer/showPrivacyPolicy.js
+++ b/src/renderer/showPrivacyPolicy.js
@@ -1,0 +1,13 @@
+import {ipcRenderer} from 'electron';
+
+const showPrivacyPolicy = event => {
+    if (event) {
+        // Probably a click on a link; don't actually follow the link in the `href` attribute.
+        event.preventDefault();
+    }
+    // tell the main process to open the privacy policy window
+    ipcRenderer.send('open-privacy-policy-window');
+    return false;
+};
+
+export default showPrivacyPolicy;


### PR DESCRIPTION
### Resolves

Resolves #97

### Proposed Changes

Along with LLK/scratch-gui#6463 this change allows the Scratch app to display its privacy policy inside the app.

Primary changes:

* add a new window to display the privacy policy
* supply an array of menu items to the GUI in `onClickAbout`, instead of just one callback function (new feature in LLK/scratch-gui#6463)

Supporting changes:

* add build config for CSS files and move existing CSS out of JSX files into separate CSS files
* simplify `app.jsx` and `about.jsx` to return a component which `index.js` now renders, instead of those components rendering themselves. The new `privacy.jsx` follows this new pattern as well.
* styling changes in the "About" window
* remove click handler from the "Scratch" logo in favor of the new "About" menu item

### Reason for Changes

Moving the "About" window from the Scratch logo to an item in a normal menu should make it easier to find.

Viewing the privacy policy in-app is not only a good idea, it's also now required by Microsoft Store policy.

Re-opening the telemetry modal on demand will allow the user to change their mind at any time, which is not required by any policy but was recommended to us and seems like a good idea anyway.
