### PR TITLE
Allow For Building on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scratch-desktop",
   "productName": "Scratch",
   "description": "Scratch 3.0 as a self-contained desktop application",
-  "author": "Scratch Foundation",
+  "author": "Scratch Foundation <help@scratch.mit.edu>",
   "version": "3.18.1",
   "license": "BSD-3-Clause",
   "scripts": {

--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -72,7 +72,7 @@ const runBuilder = function (wrapperConfig, target) {
     }
     allArgs = allArgs.concat(wrapperConfig.builderArgs);
     console.log(`running electron-builder with arguments: ${allArgs}`);
-    const result = spawnSync('electron-builder', allArgs, {
+    const result = spawnSync('./node_modules/.bin/electron-builder', allArgs, {
         env: childEnvironment,
         shell: true,
         stdio: 'inherit'
@@ -116,6 +116,10 @@ const calculateTargets = function (wrapperConfig) {
         windowsDirectDownload: {
             name: 'nsis:ia32',
             platform: 'win32'
+        },
+        linuxDeb: {
+            name: 'deb',
+            platform: 'linux'
         }
     };
     const targets = [];
@@ -143,6 +147,9 @@ const calculateTargets = function (wrapperConfig) {
             console.log(`skipping target "${availableTargets.macAppStore.name}" because code-signing is disabled`);
         }
         targets.push(availableTargets.macDirectDownload);
+        break;
+    case 'linux':
+        targets.push(availableTargets.linuxDeb);
         break;
     default:
         throw new Error(`Could not determine targets for platform: ${process.platform}`);

--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -70,9 +70,18 @@ const runBuilder = function (wrapperConfig, target) {
     if (!wrapperConfig.doPackage) {
         allArgs.push('--dir', '--c.compression=store');
     }
+    
+    //Added to fix Windows Build
+
+    if (target.platform === 'win32') {
+        var builderPath = 'electron-builder'
+    } else {
+        var builderPath = './node_modules/.bin/electron-builder'
+    }
+
     allArgs = allArgs.concat(wrapperConfig.builderArgs);
     console.log(`running electron-builder with arguments: ${allArgs}`);
-    const result = spawnSync('./node_modules/.bin/electron-builder', allArgs, {
+    const result = spawnSync(builderPath, allArgs, {
         env: childEnvironment,
         shell: true,
         stdio: 'inherit'


### PR DESCRIPTION
### Resolves

__What Github issue does this resolve (please include link)?__ 
None, I just want to build on Linux.

### Proposed Changes
__Describe what this Pull Request Does__
Allows For Building on Linux. It gave errors on Linux before.

### Reason for Changes

__Explain why these changes should be made__
Because a lot of people want to use Scratch Desktop on Linux.

### Test Coverage

__Please show how you have added tests to cover your changes__
I built a .deb file without errors on Linux (Ubuntu 20.04 64-bit).

Please change the Email if necessary(on package.json), I didn't know what to put there, but it was apparently a requirement on Linux.