### PR TITLE
Support to build on linux platform

### DIFF
--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -116,6 +116,14 @@ const calculateTargets = function (wrapperConfig) {
         windowsDirectDownload: {
             name: 'nsis:ia32',
             platform: 'win32'
+        },
+        linuxAppImage: {
+            name: 'AppImage',
+            platform: 'linux'
+        },
+        linuxAppImageDeb: {
+            name: 'deb',
+            platform: 'linux'
         }
     };
     const targets = [];
@@ -143,6 +151,10 @@ const calculateTargets = function (wrapperConfig) {
             console.log(`skipping target "${availableTargets.macAppStore.name}" because code-signing is disabled`);
         }
         targets.push(availableTargets.macDirectDownload);
+        break;
+    case 'linux':
+        targets.push(availableTargets.linuxAppImage);
+        targets.push(availableTargets.linuxAppImageDeb); // for generate deb file. Need change if not use debian/ubuntu
         break;
     default:
         throw new Error(`Could not determine targets for platform: ${process.platform}`);


### PR DESCRIPTION
### Resolves

https://github.com/LLK/scratch-desktop/issues/117

- Resolves #

### Proposed Changes

- Add linux target for `electron-builder-wrapper.js`

### Reason for Changes

- `electron` is cross platform tool. And `scratch desktop` is widely used in many platform. 
- `scratch desktop` should support build on both `windows`, `macos` and `linux` by default

### Test Coverage

- run `npm run build` and find the result in the `dist` folder
- Currently, include both `AppImage` and `deb`, if compile for all linux, can remove that line. Or change to other target, such as `rpm`, `apk`...
