### PR TITLE
Made `npm run dist` on Linux build an app image.

### DIFF
--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -117,6 +117,10 @@ const calculateTargets = function (wrapperConfig) {
         windowsDirectDownload: {
             name: 'nsis:ia32',
             platform: 'win32'
+        },
+        linuxAppImage: {
+            name: 'appImage',
+            platform: 'linux'
         }
     };
     const targets = [];
@@ -144,6 +148,9 @@ const calculateTargets = function (wrapperConfig) {
             console.log(`skipping target "${availableTargets.macAppStore.name}" because code-signing is disabled`);
         }
         targets.push(availableTargets.macDirectDownload);
+        break;
+    case 'linux':
+        targets.push(availableTargets.linuxAppImage);
         break;
     default:
         throw new Error(`Could not determine targets for platform: ${process.platform}`);


### PR DESCRIPTION
### Proposed Changes

Make `npm run dist` on Linux build an app image instead of just erroring out.

### Reason for Changes

As discussed in #117, there is no bandwidth for official Linux releases, but this at least makes getting a working Linux binary from source quite easy.

An app image is a self-contained binary.
Unlike deb, rpm and flatpak, creating an app image doesn't seem to require installing any external tooling.

(Also tagging related: #416)
