### PR TITLE
fix: explicitly specify notarytool for mac notarization

### DIFF
--- a/scripts/afterSign.js
+++ b/scripts/afterSign.js
@@ -29,7 +29,8 @@ const notarizeMacBuild = async function (context) {
         appBundleId: appId,
         appPath: `${appOutDir}/${productFilename}.app`,
         appleId,
-        appleIdPassword: process.env.AC_PASSWORD || `@keychain:${appleIdKeychainItem}`
+        appleIdPassword: process.env.AC_PASSWORD || `@keychain:${appleIdKeychainItem}`,
+        tool: 'notarytool'
     });
 };
 


### PR DESCRIPTION
### Proposed Changes

Explicitly specify notarytool for notarization of Mac builds
