### PR TITLE
fix: provide teamid to notarytool

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,8 @@ jobs:
         SCRATCH_SHOULD_SIGN: ${{ github.ref_name == 'develop' && matrix.os != 'windows-latest' }}
         AC_USERNAME: ${{ (github.ref_name == 'develop' && secrets.AC_USERNAME) || '' }}
         AC_PASSWORD: ${{ (github.ref_name == 'develop' && secrets.AC_PASSWORD) || '' }}
+        # Required for notarization on Mac
+        AC_TEAM_ID: ${{ secrets.AC_TEAM_ID || 'W7AR3WMP87' }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,3 +1,3 @@
-app_identifier "edu.mit.scratch.scratch-desktop" # The bundle identifier of your app
-apple_id "bot-apple@scratch.mit.edu" # Your Apple email address
-team_id "W7AR3WMP87"
+app_identifier("edu.mit.scratch.scratch-desktop") # The bundle identifier of your app
+apple_id("bot-apple@scratch.mit.edu") # Your Apple email address
+team_id(ENV.fetch("AC_TEAM_ID"))

--- a/scripts/afterSign.js
+++ b/scripts/afterSign.js
@@ -30,6 +30,7 @@ const notarizeMacBuild = async function (context) {
         appPath: `${appOutDir}/${productFilename}.app`,
         appleId,
         appleIdPassword: process.env.AC_PASSWORD || `@keychain:${appleIdKeychainItem}`,
+        teamId: process.env.AC_TEAM_ID || '',
         tool: 'notarytool'
     });
 };


### PR DESCRIPTION
### Proposed Changes

Export team_id as an env variable with a default value (the same which was previously used in the Appfile) and pass it in the cicd, so that it is available for the electron-builder.

### Reason for Changes

Notarization via notarytool cannot infer team_id on its own - it needs to be passed explicitly
