### PR TITLE
feat: support universal architecture builds for mac

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,9 +81,9 @@ jobs:
         if: matrix.os == 'macos-latest' && env.SCRATCH_SHOULD_SIGN == 'true'
         run: |
           NPM_APP_VERSION="`node -pe "require('./package.json').version"`"
-          cd dist/mas-dev
+          cd dist/mas-dev-universal
           ditto -v -c -k --sequesterRsrc --keepParent --zlibCompressionLevel 9 \
-            Scratch*.app ../mas-dev-${NPM_APP_VERSION}.zip
+            Scratch*.app ../mas-dev-universal-${NPM_APP_VERSION}.zip
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: matrix.os == 'macos-latest'
@@ -91,8 +91,8 @@ jobs:
           name: macOS
           path: |
             dist/Scratch*.dmg
-            dist/mas/Scratch*.pkg
-            dist/mas-dev-*.zip
+            dist/mas-universal/Scratch*.pkg
+            dist/mas-dev-universal-*.zip
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: matrix.os == 'windows-latest'

--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -59,6 +59,8 @@ const runBuilder = function (wrapperConfig, target) {
     let allArgs = [platformFlag, target.name];
     if (target.platform === 'darwin') {
         allArgs.push(`--c.mac.type=${wrapperConfig.mode === 'dist' ? 'distribution' : 'development'}`);
+        // this needs to be built on an arm64 mac, in order for the executable to be able
+        // to run on both x86-64 and arm64 architectures. 
         allArgs.push('--universal');
         if (target.name === 'mas-dev') {
             allArgs.push(`--c.mac.provisioningProfile=${masDevProfile}`);

--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -59,6 +59,7 @@ const runBuilder = function (wrapperConfig, target) {
     let allArgs = [platformFlag, target.name];
     if (target.platform === 'darwin') {
         allArgs.push(`--c.mac.type=${wrapperConfig.mode === 'dist' ? 'distribution' : 'development'}`);
+        allArgs.push('--universal');
         if (target.name === 'mas-dev') {
             allArgs.push(`--c.mac.provisioningProfile=${masDevProfile}`);
         }


### PR DESCRIPTION
### Proposed Changes

Support universal architecture mac builds

### Reason for Changes

Ideally, we want to support mac users with both intel and arm64 architectures. Building just arm64 builds will mean intel mac users are not able to run the Scratch app anymore.
