### PR TITLE
fix: copy chunk files required for loading translated tutorial images

### DIFF
--- a/webpack.renderer.js
+++ b/webpack.renderer.js
@@ -85,6 +85,12 @@ module.exports = makeConfig(
                         from: path.join(getModulePath('@scratch/scratch-gui'), 'libraries'),
                         to: 'static/libraries',
                         flatten: true
+                    },
+                    {
+                        // We need to copy the chunks for translating tutorial images for
+                        // the tutorial translations to work.
+                        from: path.join(getModulePath('@scratch/scratch-gui'), 'chunks'),
+                        to: 'chunks'
                     }
                     // This still results in a missing fetch worker error, because the fetch-worker
                     // is attempted to be resolved on an absolute path (e.g. file:///chunks/fetch-worker..)


### PR DESCRIPTION
### Resolves
https://scratchfoundation.atlassian.net/browse/UEPR-261

### Proposed Changes

Copy chunk files from GUI to the desktop renderer bundle

### Reason for Changes

Translated tutorial images are not being loaded, due to the necessary chunks with the tutorial image scripts are missing from the desktop bundle.

