### PR TITLE
chore: bump package.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scratch-desktop",
-  "version": "3.31.0",
+  "version": "3.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scratch-desktop",
-      "version": "3.31.0",
+      "version": "3.31.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "source-map-support": "0.5.19"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Scratch",
   "description": "Scratch 3.0 as a self-contained desktop application",
   "author": "Scratch Foundation",
-  "version": "3.31.0",
+  "version": "3.31.1",
   "license": "AGPL-3.0-only",
   "main": "./dist/main/main.js",
   "scripts": {


### PR DESCRIPTION
Bump package.json version to ensure the store versions are uniquely identified