### PR TITLE
fix(win): Allow saving projects to the root of any drive

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -321,7 +321,15 @@ const createMainWindow = () => {
                         // The download was canceled or interrupted. Cancel the telemetry event and delete the file.
                         throw new Error(`save ${doneState}`); // "save cancelled" or "save interrupted"
                     }
-                    await fs.move(tempPath, userChosenPath, {overwrite: true});
+                    // fs.move fails on Windows when saving to the root of a drive.
+                    // Work around this by using copyFile and unlink instead.
+                    const destDir = path.dirname(userChosenPath);
+                    if (process.platform === 'win32' && destDir === path.parse(destDir).root) {
+                        await fs.copyFile(tempPath, userChosenPath);
+                        await fs.unlink(tempPath);
+                    } else {
+                        await fs.move(tempPath, userChosenPath, {overwrite: true});
+                    }
                     if (isProjectSave) {
                         const newProjectTitle = path.basename(userChosenPath, extName);
                         webContents.send('setTitleFromSave', {title: newProjectTitle});


### PR DESCRIPTION
## Summary

On Windows, saving a project to the root of a non-system drive (e.g., D:\) would fail with an `EPERM` error. This was caused by `fs.move` attempting to create the root directory, which is a restricted operation. This fix detects when a save is targeted for the root of a drive on Windows and uses an alternative `copy` and `unlink` method to move the file, avoiding the permissions error.

## Changes

- **src/main/index.js**: On Windows, `fs.move` fails when the destination is the root of a drive because it attempts to `mkdir` the root directory. This change adds a workaround to detect this specific scenario and use `fs.copyFile` and `fs.unlink` instead, which do not have this issue.

## Related Issue

Closes #176

