### PR TITLE
fix(deps): replace nets with Electron net.request in telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "minilog": "3.1.0",
         "minimist": "1.2.8",
         "mkdirp": "1.0.4",
-        "nets": "3.2.0",
         "postcss-import": "12.0.1",
         "postcss-loader": "4.3.0",
         "postcss-simple-vars": "5.0.2",
@@ -17824,17 +17823,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nets": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nets/-/nets-3.2.0.tgz",
-      "integrity": "sha512-5644wFwLQzom2zx/4CzQXO8OcOADf1otKe5vUvfAqXes18gruSv18wGIBHlNclTGQuOOLgzGPYKen26tfNIfBQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "request": "^2.65.0",
-        "xhr": "^2.1.0"
-      }
     },
     "node_modules/no-case": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "minilog": "3.1.0",
     "minimist": "1.2.8",
     "mkdirp": "1.0.4",
-    "nets": "3.2.0",
     "postcss-import": "12.0.1",
     "postcss-loader": "4.3.0",
     "postcss-simple-vars": "5.0.2",

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -1,10 +1,31 @@
+import {net} from 'electron';
 import ElectronStore from 'electron-store';
-import nets from 'nets';
 import * as os from 'os';
 import {
     v1 as uuidv1, // semi-persistent client ID
     v4 as uuidv4 // random ID
 } from 'uuid';
+
+/**
+ * Minimal `nets`-shaped wrapper around Electron's `net.request`. Calls
+ * `callback(err)` on transport error, or `callback(null, {statusCode})` when
+ * the response is complete. The response body is drained and discarded since
+ * this client only cares about status codes.
+ * @param {object} opts - {method, url, headers, body}
+ * @param {function(Error?, {statusCode: number}=): void} callback - completion callback
+ */
+const httpRequest = (opts, callback) => {
+    const request = net.request({method: opts.method, url: opts.url, headers: opts.headers});
+    request.on('response', response => {
+        response.on('data', () => {}); // drain so 'end' fires
+        response.on('end', () => callback(null, {statusCode: response.statusCode}));
+    });
+    request.on('error', err => callback(err));
+    if (opts.body) {
+        request.write(opts.body);
+    }
+    request.end();
+};
 
 /**
  * Basic telemetry event data. These fields are filled automatically by the `addEvent` call.
@@ -260,7 +281,7 @@ class TelemetryClient {
             const packetInfo = this._packetQueue.shift();
             ++packetInfo.attempts;
             const packet = packetInfo.packet;
-            nets({
+            httpRequest({
                 body: JSON.stringify(packet),
                 headers: {'Content-Type': 'application/json'},
                 method: 'POST',
@@ -288,7 +309,7 @@ class TelemetryClient {
      * Check if the telemetry service is available
      */
     _updateNetworkStatus () {
-        nets({
+        httpRequest({
             method: 'GET',
             url: this._serverURL
         }, (err, res) => {

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -1,4 +1,4 @@
-import {net} from 'electron';
+import {app, net} from 'electron';
 import ElectronStore from 'electron-store';
 import * as os from 'os';
 import {
@@ -10,21 +10,26 @@ import {
  * Minimal `nets`-shaped wrapper around Electron's `net.request`. Calls
  * `callback(err)` on transport error, or `callback(null, {statusCode})` when
  * the response is complete. The response body is drained and discarded since
- * this client only cares about status codes.
+ * this client only cares about status codes. Waits for `app.whenReady()`
+ * before dispatching, because `net.request` throws if used pre-ready and
+ * the TelemetryClient constructor may schedule requests before that point.
  * @param {object} opts - {method, url, headers, body}
  * @param {function(Error?, {statusCode: number}=): void} callback - completion callback
  */
 const httpRequest = (opts, callback) => {
-    const request = net.request({method: opts.method, url: opts.url, headers: opts.headers});
-    request.on('response', response => {
-        response.on('data', () => {}); // drain so 'end' fires
-        response.on('end', () => callback(null, {statusCode: response.statusCode}));
-    });
-    request.on('error', err => callback(err));
-    if (opts.body) {
-        request.write(opts.body);
-    }
-    request.end();
+    app.whenReady().then(() => {
+        const request = net.request({method: opts.method, url: opts.url, headers: opts.headers});
+        request.on('response', response => {
+            response.on('data', () => {}); // drain so 'end' fires
+            response.on('end', () => callback(null, {statusCode: response.statusCode}));
+        });
+        request.on('error', err => callback(err));
+        if (opts.body) {
+            request.write(opts.body);
+        }
+        request.end();
+    })
+        .catch(err => callback(err));
 };
 
 /**

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -43,15 +43,9 @@ const httpRequest = (opts, callback) => {
  */
 
 /**
-  * Default telemetry service URLs
-  */
-const TelemetryServerURL = Object.freeze({
-    staging: 'http://scratch-telemetry-staging.us-east-1.elasticbeanstalk.com/',
-    production: 'https://telemetry.scratch.mit.edu/'
-});
-const DefaultServerURL = (
-    process.env.NODE_ENV === 'production' ? TelemetryServerURL.production : TelemetryServerURL.staging
-);
+ * Default telemetry service URL. Production and staging both target the same endpoint.
+ */
+const DefaultServerURL = 'https://telemetry.scratch.mit.edu/';
 
 /**
  * Default name for persistent configuration & queue storage

--- a/src/main/telemetry/TelemetryClient.js
+++ b/src/main/telemetry/TelemetryClient.js
@@ -8,28 +8,40 @@ import {
 
 /**
  * Minimal `nets`-shaped wrapper around Electron's `net.request`. Calls
- * `callback(err)` on transport error, or `callback(null, {statusCode})` when
- * the response is complete. The response body is drained and discarded since
- * this client only cares about status codes. Waits for `app.whenReady()`
- * before dispatching, because `net.request` throws if used pre-ready and
- * the TelemetryClient constructor may schedule requests before that point.
+ * `callback(err)` on transport or response-stream error, or
+ * `callback(null, {statusCode})` when the response is complete. The
+ * response body is drained and discarded since this client only cares
+ * about status codes. The callback fires at most once, so callers can
+ * rely on it as a single completion seam.
+ *
+ * Waits for `app.whenReady()` before dispatching, because `net.request`
+ * throws if used pre-ready and the TelemetryClient constructor may
+ * schedule requests before that point.
  * @param {object} opts - {method, url, headers, body}
  * @param {function(Error?, {statusCode: number}=): void} callback - completion callback
  */
 const httpRequest = (opts, callback) => {
+    let settled = false;
+    const done = (err, res) => {
+        if (settled) return;
+        settled = true;
+        callback(err, res);
+    };
     app.whenReady().then(() => {
         const request = net.request({method: opts.method, url: opts.url, headers: opts.headers});
         request.on('response', response => {
             response.on('data', () => {}); // drain so 'end' fires
-            response.on('end', () => callback(null, {statusCode: response.statusCode}));
+            response.on('end', () => done(null, {statusCode: response.statusCode}));
+            response.on('error', err => done(err));
+            response.on('aborted', () => done(new Error('response aborted')));
         });
-        request.on('error', err => callback(err));
+        request.on('error', err => done(err));
         if (opts.body) {
             request.write(opts.body);
         }
         request.end();
     })
-        .catch(err => callback(err));
+        .catch(err => done(err));
 };
 
 /**


### PR DESCRIPTION
### Proposed Changes

- Replace `nets` with Electron's `net.request` in `src/main/telemetry/TelemetryClient.js`.
- Remove `nets` from `devDependencies` (also drops the `nets → request → form-data/tough-cookie/qs/cookie` transitive chain from the runtime tree).
- Introduce a small `httpRequest(opts, callback)` helper that wraps `net.request` in the same `(err, res) => …` signature `nets` exposed, so the two existing call sites stay structurally identical.

### Reason for Changes

`nets` is unmaintained and pulls in a deprecated `request` chain that's the source of several open Dependabot alerts: **critical** `form-data` (unsafe random), and **medium** alerts for `request` (SSRF), `tough-cookie` (prototype pollution), `qs` (DoS), and `cookie` (OOB).

Beyond closing CVEs, this aligns telemetry with the rest of the app's networking. With `nets`, telemetry took its own path through Node's HTTP stack — invisible to whatever proxy or filter the rest of the app was sitting behind. With `net.request`, telemetry now uses the same Chromium networking stack as the editor itself: system proxy settings, OS cert handling, and Electron-session policies all apply consistently. Schools and parents who set up filters or proxies expecting all the app's network traffic to flow through them will get that behavior.

### What's preserved

Everything the telemetry client does *with* the network stays the same:

- Same packet shape (clientID, packet UUID, event name, platform string, timestamp, timezone).
- Same opt-in semantics, queue limit (100), retry limit (3), and connectivity-check cadence.
- Same callback contract inside the class (`(err, {statusCode}) => …`).

### Changes added after initial review

**Server URL.** Telemetry now targets `https://telemetry.scratch.mit.edu/` regardless of `NODE_ENV`. The previous staging endpoint has been retired; both production and staging builds use the same server going forward.

**Wrapper shape.** The `nets`-shaped callback wrapper was an intentional choice to keep the two call sites structurally identical, but `net.request` is event-stream-based rather than one-shot. The wrapper now listens for response-stream `error` and `aborted` events in addition to `request.error`, and routes every completion path through a once-guard so the callback fires at most once even if multiple events land. Promise-shaping the helper was considered but would have pulled the delivery-loop recursion into a different shape; that refactor is worth doing separately, not in this PR.

### Verification

- `npm run test:lint` passes with 0 errors locally on node 24.15.0 (baseline jsdoc warnings unchanged).
- `npm run compile` builds both renderer and main bundles successfully.
- Bundled `dist/main/main.js` contains no `require('nets')` calls.
- **Electron runtime smoke test pending** — needs an `npm start` opt-in run to confirm a telemetry POST lands at the production server with status 200 and the connectivity-check GET flips `_networkIsOnline` correctly.

### Dependabot scope note

This PR closes the path `nets → request → form-data/tough-cookie/qs/cookie` through the dependency tree. The *same chain* is also reachable via `@scratch/scratch-gui → scratch-l10n → transifex`, but those calls only run at `scratch-l10n` build time (not at scratch-desktop build or runtime), so they aren't a runtime exposure here. Dependabot's flat view may still show some of the underlying alerts as open until `scratch-l10n` is updated separately — that's tracked in its own repo.

### Out of scope

Not addressing other unrelated Dependabot alerts (hull.js, tar, serialize-javascript) — separate work.
