### PR TITLE
ci: split CI and release-candidate into separate workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,22 +83,22 @@ jobs:
       run:
         shell: bash
     env:
-        # Temporary workaround: Windows signing is currently broken due to
-        # a security-policy change. See
-        # https://github.com/electron/windows-installer/issues/473
-        # While this is true, the release-candidate job still runs Windows
-        # through the build (so we get an installer artifact) but skips
-        # the signing step.
-        SCRATCH_SHOULD_SIGN: ${{ matrix.os != 'windows-latest' }}
-        # App Store Connect API key — fastlane and electron-builder read
-        # different env var names but use the same credentials. The .p8
-        # file path (APPLE_API_KEY / APP_STORE_CONNECT_API_KEY_KEY_FILEPATH)
-        # is written and exported by the "Decode App Store Connect API Key"
-        # step below.
-        APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-        APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-        APPLE_API_KEY_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-        APPLE_API_ISSUER: ${{ vars.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      # Temporary workaround: Windows signing is currently broken due to
+      # a security-policy change. See
+      # https://github.com/electron/windows-installer/issues/473
+      # While this is true, the release-candidate job still runs Windows
+      # through the build (so we get an installer artifact) but skips
+      # the signing step.
+      SCRATCH_SHOULD_SIGN: ${{ matrix.os != 'windows-latest' }}
+      # App Store Connect API key — fastlane and electron-builder read
+      # different env var names but use the same credentials. The .p8
+      # file path (APPLE_API_KEY / APP_STORE_CONNECT_API_KEY_KEY_FILEPATH)
+      # is written and exported by the "Decode App Store Connect API Key"
+      # step below.
+      APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+      APPLE_API_KEY_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+      APPLE_API_ISSUER: ${{ vars.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
     steps:
       # Re-check out the same SHA the ci job tested. Tier 1: source-identical
       # rebuild. The binary may differ in non-meaningful ways (timestamps,
@@ -125,27 +125,27 @@ jobs:
         if: matrix.os == 'macos-latest'
         uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
-            ssh-private-key: ${{ secrets.FASTLANE_ACCESS_KEY }}
+          ssh-private-key: ${{ secrets.FASTLANE_ACCESS_KEY }}
       - name: Decode App Store Connect API Key
         if: matrix.os == 'macos-latest'
         env:
-            APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         run: |
-            KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
-            printf '%s' "$APP_STORE_CONNECT_API_KEY_KEY" | base64 -d > "$KEY_PATH"
-            chmod 600 "$KEY_PATH"
-            echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
-            echo "APP_STORE_CONNECT_API_KEY_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_KEY" | base64 -d > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
+          echo "APP_STORE_CONNECT_API_KEY_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
       - name: Setup Ruby
         if: matrix.os == 'macos-latest'
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
-            bundler-cache: true
+          bundler-cache: true
       - name: Fastlane
         env:
-            GIT_URL: ${{ secrets.FL_GIT_URL }}
-            STORAGE_MODE: ${{ vars.FL_STORAGE_MODE }}
-            MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          GIT_URL: ${{ secrets.FL_GIT_URL }}
+          STORAGE_MODE: ${{ vars.FL_STORAGE_MODE }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         if: matrix.os == 'macos-latest'
         run: bundle exec fastlane prepare_signing
       - name: Build (signed)
@@ -155,8 +155,10 @@ jobs:
           # Only expose Windows code-signing secrets to runs that will use them.
           # SCRATCH_SHOULD_SIGN is currently false on Windows (temporary workaround above);
           # both expressions evaluate to '' until Windows signing is re-enabled.
-          WIN_CSC_LINK: ${{ matrix.os == 'windows-latest' && env.SCRATCH_SHOULD_SIGN == 'true' && secrets.WIN_CSC_LINK || '' }}
-          WIN_CSC_KEY_PASSWORD: ${{ matrix.os == 'windows-latest' && env.SCRATCH_SHOULD_SIGN == 'true' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
+          WIN_CSC_LINK: ${{ matrix.os == 'windows-latest' && env.SCRATCH_SHOULD_SIGN == 'true' && secrets.WIN_CSC_LINK ||
+            '' }}
+          WIN_CSC_KEY_PASSWORD: ${{ matrix.os == 'windows-latest' && env.SCRATCH_SHOULD_SIGN == 'true' && secrets.WIN_CSC_KEY_PASSWORD
+            || '' }}
         run: npm run ${{ env.SCRATCH_SHOULD_SIGN == 'true' && 'dist' || 'distDev' }}
       - name: Zip MAS-Dev build
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+on:
+  push:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - name: Debug info
+        run: |
+          cat <<EOF
+          Node version: $(node --version)
+          NPM version: $(npm --version)
+          GitHub ref: ${{ github.ref }}
+          GitHub head ref: ${{ github.head_ref }}
+          Working directory: $(pwd)
+          EOF
+      - name: Install NPM dependencies
+        run: npm ci
+      - name: Test
+        run: npm run test
+      - name: Build
+        timeout-minutes: 30
+        env:
+          # TODO: fix whatever is causing excessive memory usage during build
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: npm run distDev
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: matrix.os == 'macos-latest'
+        with:
+          name: macOS-unsigned
+          path: dist/Scratch*.dmg
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: matrix.os == 'windows-latest'
+        with:
+          name: Windows-unsigned
+          path: |
+            dist/Scratch*.appx
+            dist/Scratch*.exe

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,6 +1,10 @@
-name: CI/CD
+name: Release Candidate
+# Builds a fully signed and notarized release candidate. Runs only when
+# dispatched manually via Actions -> Run workflow; the dispatcher should
+# verify that CI is green for the chosen ref before clicking. Gated by
+# the 'release-candidate' GitHub Environment, which must be configured
+# with required reviewers under Settings -> Environments.
 on:
-  push:
   workflow_dispatch:
 
 concurrency:
@@ -10,66 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    strategy:
-      matrix:
-        os:
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          cache: 'npm'
-          node-version-file: '.nvmrc'
-      - name: Debug info
-        run: |
-          cat <<EOF
-          Node version: $(node --version)
-          NPM version: $(npm --version)
-          GitHub ref: ${{ github.ref }}
-          GitHub head ref: ${{ github.head_ref }}
-          Working directory: $(pwd)
-          EOF
-      - name: Install NPM dependencies
-        run: npm ci
-      - name: Test
-        run: npm run test
-      - name: Build
-        timeout-minutes: 30
-        env:
-          # TODO: fix whatever is causing excessive memory usage during build
-          NODE_OPTIONS: --max-old-space-size=4096
-        run: npm run distDev
-      - name: Upload macOS artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: matrix.os == 'macos-latest'
-        with:
-          name: macOS-unsigned
-          path: dist/Scratch*.dmg
-      - name: Upload Windows artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: matrix.os == 'windows-latest'
-        with:
-          name: Windows-unsigned
-          path: |
-            dist/Scratch*.appx
-            dist/Scratch*.exe
-
-  # Builds a fully signed and notarized release candidate. Gated by the
-  # 'release-candidate' GitHub Environment, which must be configured with
-  # required reviewers under Settings -> Environments. Runs after ci on
-  # develop pushes, or on manual workflow_dispatch from any branch
-  # (use the "Run workflow" button to pick which ref to release).
   release-candidate:
-    needs: ci
-    if: |
-      (github.event_name == 'push' && github.ref_name == 'develop') ||
-      github.event_name == 'workflow_dispatch'
     environment: release-candidate
     permissions:
       contents: read
@@ -100,9 +45,9 @@ jobs:
       APPLE_API_KEY_ID: ${{ vars.APP_STORE_CONNECT_API_KEY_KEY_ID }}
       APPLE_API_ISSUER: ${{ vars.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
     steps:
-      # Re-check out the same SHA the ci job tested. Tier 1: source-identical
-      # rebuild. The binary may differ in non-meaningful ways (timestamps,
-      # webpack chunk order); the source is exactly what passed CI.
+      # Pin the checkout to the SHA that was current when this workflow
+      # was dispatched. Without this, actions/checkout defaults to the
+      # tip of the selected ref, which could move during the run.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}


### PR DESCRIPTION
### Proposed Changes

Split `.github/workflows/ci-cd.yml` into two workflow files:

- `ci.yml` runs the unsigned-artifact `ci` matrix on every push and on `workflow_dispatch`. Behavior is identical to the old `ci:` job.
- `release-candidate.yml` runs the signed/notarized release-candidate matrix only on `workflow_dispatch`. The old `if:` condition that ran the job on every push to develop is gone; the "Run workflow" click is now the affirmation step.

The old `needs: ci` cross-job dependency is dropped along with the file. The dispatcher checks the CI badge on the chosen ref before clicking Run workflow.

Two commits, independently revertable: a yamlfmt sweep on the original file, then the split itself.

### Reason for Changes

The previous setup auto-queued the `release-candidate` job at its environment approval gate on every push to develop. In practice the approval was almost always declined, and a stale gate from one push blocked subsequent CI runs because the workflow's `concurrency:` group had no `cancel-in-progress`. Newer pushes queued behind the unanswered gate.

The two jobs have meaningfully different roles, schedules, and permission needs: `ci` runs unsigned on every push for fast feedback, `release-candidate` is heavyweight and signed and should run only when explicitly asked. Keeping them in one file was historical, not structural; splitting them makes the trigger match the file's purpose. The environment's required-reviewers gate still applies during the run as defense in depth.

### Verification

- Both new workflow files pass the repo's treefmt hook (`yamlfmt` and `actionlint`).
- The split is detected by git as a rename of `ci-cd.yml` to `release-candidate.yml` (68% similarity), so blame history survives.
- **Post-merge:**
    - Push to develop should trigger only `CI` (not `Release Candidate`).
    - Dispatch `Release Candidate` against a develop SHA via Run workflow should exercise the signing/notarization path through the environment-approval gate as before, producing the same artifacts as the old `release-candidate` job.
