### PR TITLE
ci: fan out release-candidate matrix into one cell per build target

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -27,12 +27,35 @@ jobs:
       contents: read
     strategy:
       # Don't cancel sibling matrix cells when one fails; let each one
-      # finish so we get artifacts and full failure signal from every OS.
+      # finish so we get artifacts and full failure signal from every cell.
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - windows-latest
+        # One cell per build target. Splitting macOS targets across three
+        # runners parallelizes Apple notarization waits, which is the
+        # dominant wall-clock cost on this workflow. Windows targets are
+        # split so an appx-only failure doesn't lose the nsis artifact
+        # (and vice versa).
+        include:
+          - os: macos-latest
+            target: mas-dev
+            artifact-name: macOS-mas-dev
+            artifact-path: dist/mas-dev-universal-*.zip
+          - os: macos-latest
+            target: mas
+            artifact-name: macOS-mas
+            artifact-path: dist/mas-universal/Scratch*.pkg
+          - os: macos-latest
+            target: dmg
+            artifact-name: macOS-dmg
+            artifact-path: dist/Scratch*.dmg
+          - os: windows-latest
+            target: appx
+            artifact-name: Windows-appx
+            artifact-path: dist/Scratch*.appx
+          - os: windows-latest
+            target: nsis
+            artifact-name: Windows-nsis
+            artifact-path: dist/Scratch*.exe
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -139,28 +162,16 @@ jobs:
             '' }}
           WIN_CSC_KEY_PASSWORD: ${{ matrix.os == 'windows-latest' && env.SCRATCH_SHOULD_SIGN == 'true' && secrets.WIN_CSC_KEY_PASSWORD
             || '' }}
-        run: npm run ${{ env.SCRATCH_SHOULD_SIGN == 'true' && 'dist' || 'distDev' }}
+        run: npm run ${{ env.SCRATCH_SHOULD_SIGN == 'true' && 'dist' || 'distDev' }} -- --target=${{ matrix.target }}
       - name: Zip MAS-Dev build
-        if: matrix.os == 'macos-latest'
+        if: matrix.target == 'mas-dev'
         run: |
           NPM_APP_VERSION="`node -pe "require('./package.json').version"`"
           cd dist/mas-dev-universal
           ditto -v -c -k --sequesterRsrc --keepParent --zlibCompressionLevel 9 \
             Scratch*.app ../mas-dev-universal-${NPM_APP_VERSION}.zip
-      - name: Upload macOS artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: matrix.os == 'macos-latest'
         with:
-          name: macOS-signed
-          path: |
-            dist/Scratch*.dmg
-            dist/mas-universal/Scratch*.pkg
-            dist/mas-dev-universal-*.zip
-      - name: Upload Windows artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: matrix.os == 'windows-latest'
-        with:
-          name: Windows-installer
-          path: |
-            dist/Scratch*.appx
-            dist/Scratch*.exe
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build:dir": "cross-env NODE_ENV=production npm run compile && npm run doBuild -- --mode=dir",
     "build:dist": "cross-env NODE_ENV=production npm run compile && npm run doBuild -- --mode=dist",
     "doBuild": "node ./scripts/electron-builder-wrapper.js",
-    "dist": "npm run clean && npm run fetch && npm run build:dist",
-    "distDev": "npm run clean && npm run fetch && npm run build:dev",
+    "dist": "npm run clean && npm run fetch && npm run build:dist --",
+    "distDev": "npm run clean && npm run fetch && npm run build:dev --",
     "test": "npm run test:lint",
     "test:lint": "eslint --cache --color ."
   },

--- a/scripts/electron-builder-wrapper.js
+++ b/scripts/electron-builder-wrapper.js
@@ -1,6 +1,9 @@
 /**
  * @overview This script runs `electron-builder` with special management of code signing configuration on Windows.
  * Running this script with no command line parameters should build all targets for the current platform.
+ * Pass `--target=<short-name>` to build exactly one target instead of the platform default set; the matrix in
+ * `release-candidate.yml` uses this to fan a multi-target serial pass out into one runner per target. Valid short
+ * names: `mas`, `mas-dev`, `dmg`, `appx`, `nsis`.
  * On Windows, make sure to set CSC_* or WIN_CSC_* environment variables or the NSIS build will fail.
  * On Mac, the CSC_* variables are optional but will be respected if present.
  * See also: https://www.electron.build/code-signing
@@ -126,6 +129,29 @@ const calculateTargets = function (wrapperConfig) {
             platform: 'linux'
         }
     };
+    // --target=<short-name> overrides the platform default and builds exactly
+    // one target. Used by the release-candidate matrix to fan a multi-target
+    // serial pass out into one runner per target. Bypasses the doSign/profile
+    // skips below: the matrix dispatcher is asserting "build this and only
+    // this", so a missing prerequisite should fail loudly rather than be
+    // silently skipped.
+    if (wrapperConfig.target) {
+        const targetsByShortName = {
+            'mas': availableTargets.macAppStore,
+            'mas-dev': availableTargets.macAppStoreDev,
+            'dmg': availableTargets.macDirectDownload,
+            'appx': availableTargets.microsoftStore,
+            'nsis': availableTargets.windowsDirectDownload
+        };
+        const selected = targetsByShortName[wrapperConfig.target];
+        if (!selected) {
+            throw new Error(
+                `Unknown --target value: "${wrapperConfig.target}". ` +
+                `Valid values: ${Object.keys(targetsByShortName).join(', ')}.`
+            );
+        }
+        return [selected];
+    }
     const targets = [];
     switch (process.platform) {
     case 'win32':
@@ -165,11 +191,15 @@ const parseArgs = function () {
     const scriptArgs = process.argv.slice(2); // remove `node` and `this-script.js`
     const builderArgs = [];
     let mode = 'dev'; // default
+    let target = null; // null = use platform-default target set
 
     for (const arg of scriptArgs) {
         const modeSplit = arg.split(/--mode(\s+|=)/);
+        const targetSplit = arg.split(/--target(\s+|=)/);
         if (modeSplit.length === 3) {
             mode = modeSplit[2];
+        } else if (targetSplit.length === 3) {
+            target = targetSplit[2];
         } else {
             builderArgs.push(arg);
         }
@@ -196,14 +226,15 @@ const parseArgs = function () {
         builderArgs,
         doPackage, // false = build to directory
         doSign,
-        mode
+        mode,
+        target,
+        targets: null // filled in by main() after calculateTargets()
     };
 };
 
 const main = function () {
     const wrapperConfig = parseArgs();
 
-    // TODO: allow user to specify targets? We could theoretically build NSIS on Mac, for example.
     wrapperConfig.targets = calculateTargets(wrapperConfig);
 
     for (const target of wrapperConfig.targets) {


### PR DESCRIPTION
### Proposed Changes

Two commits:

- **`chore(scripts): add --target flag to electron-builder-wrapper`.** Adds a `--target=<short-name>` CLI flag to `scripts/electron-builder-wrapper.js`. When set, the wrapper builds exactly one target and bypasses the default doSign/profile-existence skips; valid short names are `mas`, `mas-dev`, `dmg`, `appx`, `nsis`. The flag is parsed locally and not forwarded to electron-builder, so it doesn't collide with anything in the underlying CLI surface.
- **`ci: fan out release-candidate.yml into one cell per target`.** Replaces the `os` matrix with a 5-cell `include:` matrix: macOS x {mas-dev, mas, dmg} and Windows x {appx, nsis}. Each cell invokes `npm run dist -- --target=<short-name>` (or `distDev` on Windows, per the existing SCRATCH_SHOULD_SIGN workaround) and uploads one target-named artifact via a single parameterized step. `fail-fast: false` from #617 remains in place.

`ci.yml` is intentionally left alone — see *Why not ci.yml?* below.

### Reason for Changes

Release-candidate wall-clock is currently 45-60 min, with Apple notarization the dominant cost inside the single macOS job. Notarization can't be parallelized within a single electron-builder invocation; only across runners. Fan-out runs mas + mas-dev + dmg concurrently across three macOS runners, with each runner waiting on its own notarization round-trip in parallel. Expected save: 15-30 min off release-candidate wall-clock.

Per the CI-optimization plan, this is the highest-impact remaining step. The wrapper's `--target` flag is the minimum-surface change that makes per-cell single-target builds possible without electron-builder fighting the existing signing/CSC handling.

### Why not ci.yml?

ci.yml runs on every push and already takes only ~6 min wall-clock post-#617. The macOS cell is the long pole at ~6m 8s and builds exactly one target (only dmg — `mas` is skipped because `distDev` is unsigned, `mas-dev` is skipped because no provisioning profile in CI). With nothing to parallelize on the long-pole runner, fan-out wouldn't reduce overall wall-clock at all. Windows has two targets but isn't the bottleneck, so fan-out there would shorten Windows by ~1m 30s while overall workflow time stays bound by macOS. The cost — one extra runner job per push — would buy zero wall-clock improvement until macOS becomes faster than Windows.

### Verification

- `npm run test:lint` passes locally with 0 errors (37 baseline jsdoc warnings unchanged).
- `node scripts/electron-builder-wrapper.js --mode=dist --target=bogus` throws a clear error listing the five valid short names.
- `node scripts/electron-builder-wrapper.js --mode=dist --target=dmg` reaches the spawn call with the correct args (`--linux,dmg,--c.mac.type=distribution,--universal` on this Linux dev box — the platform flag will be `--macos` on the actual runner).
- Workflow YAML validates cleanly under yamllint.

**Post-merge / on first dispatch:**
- Five matrix cells appear in the Actions run page, all running concurrently after the environment-approval gate.
- Artifacts page shows five named artifacts: `macOS-mas-dev`, `macOS-mas`, `macOS-dmg`, `Windows-appx`, `Windows-nsis`.
- Wall-clock on the run should drop noticeably from the pre-PR baseline (15-30 min target).
- If any single cell fails, the other four still complete and upload their artifacts (no fail-fast cancellation).

### Deferred follow-ups

- Optional aggregator job that downloads the three macOS artifacts and re-bundles them into a single `macOS-signed` artifact for the release process. Not blocking — release-process scripts can be tweaked to grab three artifacts instead, and QA finds the per-target split easier to inspect.
- Two-phase per-OS setup -> per-target build structure. Cleaner architecture but marginal wall-clock win over flat matrix; revisit only if the flat matrix's runner overhead becomes a problem.
- Pull compile output from latest green CI run to skip phase 1 entirely. Biggest remaining single wall-clock cut but reintroduces a soft CI -> release-candidate dependency that PR #615 deliberately removed.